### PR TITLE
Miscellaneous improvements to license/exception parsing and codegen data update robustness

### DIFF
--- a/scripts/codegen-license-update.js
+++ b/scripts/codegen-license-update.js
@@ -130,7 +130,10 @@ const unique = (listOfWords) => {
 }
 
 const expandListOfKnownLicenses = (ids) => {
-    ids.filter(id => !!id && id.endsWith('+')).forEach(id => ids.push(id.replace(/\+$/, '-or-later')))
+    ids.filter(id => !!id && id.endsWith('+')).forEach(id => {
+        ids.push(id.replace(/\+$/, '-or-later'))
+        ids.push(id.replace(/\+$/, '-and-later'))
+    })
     return ids
 }
 
@@ -143,6 +146,9 @@ const expandListOfMentionedLicenses = (words) => {
         words.push('lgpl-2.0')
         words.push('lgpl-2.1')
         words.push('lgpl-3.0')
+    })
+    words.filter(w => w.match(/^[al]?gpl.*\-and\-later$/)).forEach(w => {
+        words.push(w.replace(/^([al]?gpl.*)\-and\-later$/, '$1-or-later'))
     })
     return words
 }

--- a/scripts/codegen-license-update.js
+++ b/scripts/codegen-license-update.js
@@ -4,7 +4,7 @@ const https = require('https')
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
-var crypto = require('crypto')
+const crypto = require('crypto')
 const { pipeline } = require('stream')
 
 
@@ -15,7 +15,7 @@ const DETAILS_DOWNLOAD_BATCH_SIZE = 10
 
 
 const hash = (str) => {
-    var shasum = crypto.createHash('sha1')
+    let shasum = crypto.createHash('sha1')
     shasum.update(str)
     return shasum.digest('hex')
 }

--- a/scripts/codegen-license-update.js
+++ b/scripts/codegen-license-update.js
@@ -38,7 +38,10 @@ const downloadJSON = async (url) => {
         return JSON.parse(rawJson)
     } catch (err) {
         console.error(`Error parsing JSON from ${url}: ${err}\n\nRaw content:\n${rawJson}`)
-        return {}
+        return {
+            error: `Error parsing JSON from ${url}: ${err}`,
+            details: `Raw content received:\n${rawJson}`
+        }
     }
 }
 
@@ -70,7 +73,7 @@ const readLicenseListVersionFromJsonObject = (jsonObj) => {
 const readLicensesFromFile = (file_path) => {
     if (fs.existsSync(file_path)) {
         const jsonObj = JSON.parse(fs.readFileSync(file_path))
-        return jsonObj.licenses
+        return jsonObj.licenses.filter(x => !!x)
     }
     console.warn(`File ${file_path} does not exist - can't read licenses from it`)
     return []
@@ -94,7 +97,7 @@ const updateFileFromURL = async (destinationFilePath, sourceUrl, entryListKey, d
         console.log(`Update available (from ${localVersion} to ${latestVersion}) --> updating ${entryListKey}`)
         const urls = json[entryListKey].map(detailsUrlMapper)
         const details = await downloadManyJSONFiles(urls)
-        json[entryListKey] = details.filter(x => !!x).map(detailsObjectMapper)
+        json[entryListKey] = details.filter(x => !!x && !x.error).map(detailsObjectMapper)
         fs.writeFileSync(destinationFilePath, JSON.stringify(json, null, 2))
         console.log(`Updated ${destinationFilePath} with version ${latestVersion} from ${sourceUrl}`)
     }

--- a/src/licenses/index.ts
+++ b/src/licenses/index.ts
@@ -84,7 +84,7 @@ const mapLicenseId = (id: string): string | undefined => {
 const fixLicenseId = (id: string): string | null => {
     // Don't try to correct license identifiers that are syntactically legit on the
     // surface and have an explicit version number such as "3.0" or "2.1":
-    if (id.match(/([a-zA-Z_0-9]+(\-[a-zA-Z_0-9]+)*)\-\d+(\.\d+)+(\-[a-zA-Z_0-9]+)*/)) {
+    if (id.match(/(\w+(\-\w+)*)\-\d+(\.\d+)+(\-\w+)*/)) {
         return id
     }
 

--- a/src/licenses/index.ts
+++ b/src/licenses/index.ts
@@ -171,17 +171,28 @@ export function correctLicenseId(identifier: string): string {
         if (id.toUpperCase() === 'LGPL') return mapLicense('LGPL-3.0-only') || id
         if (id.toUpperCase() === 'AGPL') return mapLicense('AGPL-3.0-only') || id
 
+        // If the id is already a known license, also check if there's a "-only" version
         if (mapLicense(id)) {
             return mapLicense(`${id}-only`) || id
         }
+
+        // Expand a single-digit "GPL2+" or "GPLv3" into a "-2.0+" or "-3.0" with the trailing zero
         if (id.match(/^([AL]?GPL)([\-vV]?)(\d)(\+?)$/)) {
             return applyGPLFixes(id.replace(/^([AL]?GPL)([\-vV]?)(\d)(\+?)$/, '$1-$3.0$4'))
         }
 
+        // Correct the '-and-later' to the canonical '-or-later'
+        if (id.match(/^([AL]?GPL.*)(\-and\-later)$/)) {
+            const candidateId = id.replace(/([AL]?GPL.*)(\-and\-later)$/, '$1-or-later')
+            return applyGPLFixes(candidateId) || id
+        }
+
+        // Expand the '+' syntax to the canonical '-or-later'
         if (id.match(/^([AL]?GPL[\-vV]?\d)(\+)$/)) {
             const candidateId = id.replace(/([AL]?GPL[\-vV]?\d)(\+)$/, '$1.0-or-later')
             return mapLicense(candidateId) || id
         }
+
         return id
     }
 

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -40,7 +40,7 @@ const expandGplLicenseVersionExpressions = (relatedLicenseIds: string[]): string
             ids.push(`${license}-only`)
             ids.push(`${license}-or-later`)
         }
-        const orLaterMatch = license.match(/^([AL]?GPL)\-(\d(\.\d)+)\-or\-later$/)
+        const orLaterMatch = license.match(/^([AL]?GPL)\-(\d(\.\d)+)\-(or|and)\-later$/)
         if (orLaterMatch) {
             // if "GPL-2.0+" or "GPL-3.0-or-later" etc.
             const licenseFamily = orLaterMatch[1]

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -230,9 +230,9 @@ describe('Common shorthands for GPL versions', () => {
     }
 
     testForVariationsOf('GPL-2.0-only', ["GPLv2", "GPL2", "GPL-2"])
-    testForVariationsOf('GPL-2.0-or-later', ["GPLv2+", "GPL2+", "GPL-2+"])
+    testForVariationsOf('GPL-2.0-or-later', ["GPLv2+", "GPL2+", "GPL-2+", "GPL-2.0-and-later", "GPLv2-and-later"])
     testForVariationsOf('GPL-3.0-only', ["GPL", "GPL3", "GPL-3", "GPLv3"])
-    testForVariationsOf('GPL-3.0-or-later', ["GPLv3+", "GPL3+", "GPL-3+"])
+    testForVariationsOf('GPL-3.0-or-later', ["GPLv3+", "GPL3+", "GPL-3+", "GPL-3.0-and-later", "GPL3-and-later"])
 
     it('"LGPL-3" is interpreted as "LGPL-3.0-only"', () => {
         expect(parse('LGPL-3')).toStrictEqual({ license: 'LGPL-3.0-only' })


### PR DESCRIPTION
7a32ec1 adds support/correction for the `-and-later` suffix, which means the same as the canonical form `-or-later`. These non-canonical forms appear, for example, in spdx.org's own license data files...

a9d1abb coerces an identifier expression without an explicit version number (e.g. "bison-exception") to whatever the exact known identifier is when that is the only known version number of said license. For example, with just one version of "Bison exception" being known (`Bison-exception-2.2`), the short hand "bison-exception" would be matched and replaced with the explicit expression, `Bison-exception-2.2`.

e723f12 makes the license/exception data update more robust against broken links on spdx.org.