### PR TITLE
Improve fuzzy matching logic in liberal mode

### DIFF
--- a/src/codegen/exceptions.json
+++ b/src/codegen/exceptions.json
@@ -1,5 +1,5 @@
 {
-  "licenseListVersion": "9ce8db0",
+  "licenseListVersion": "17632be",
   "exceptions": [
     {
       "licenseExceptionId": "389-exception",
@@ -49,6 +49,17 @@
         "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright",
         "https://tracker.debian.org/media/packages/s/sipwitch/copyright-1.9.15-3",
         "https://opensource.apple.com/source/launchd/launchd-258.1/launchd/compile.auto.html"
+      ],
+      "relatedLicenses": []
+    },
+    {
+      "licenseExceptionId": "Autoconf-exception-macro",
+      "isDeprecatedLicenseId": false,
+      "name": "Autoconf macro exception",
+      "seeAlso": [
+        "https://github.com/freedesktop/xorg-macros/blob/39f07f7db58ebbf3dcb64a2bf9098ed5cf3d1223/xorg-macros.m4.in",
+        "https://www.gnu.org/software/autoconf-archive/ax_pthread.html",
+        "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright"
       ],
       "relatedLicenses": []
     },
@@ -462,7 +473,9 @@
         "https://github.com/maranget/hevea/blob/master/LICENSE"
       ],
       "licenseComments": "This exception is primarily used with QPL-1.0-INRIA-2004",
-      "relatedLicenses": []
+      "relatedLicenses": [
+        "QPL-1.0-INRIA-2004"
+      ]
     },
     {
       "licenseExceptionId": "Qt-GPL-exception-1.0",
@@ -592,5 +605,5 @@
       "relatedLicenses": []
     }
   ],
-  "releaseDate": "2023-02-16"
+  "releaseDate": "2023-02-23"
 }

--- a/src/codegen/licenses.json
+++ b/src/codegen/licenses.json
@@ -1,5 +1,5 @@
 {
-  "licenseListVersion": "9ce8db0",
+  "licenseListVersion": "17632be",
   "licenses": [
     {
       "name": "BSD Zero Clause License",
@@ -30,6 +30,18 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/Abstyles"
+      ]
+    },
+    {
+      "name": "AdaCore Doc License",
+      "licenseId": "AdaCore-doc",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/AdaCore/xmlada/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-core/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-db/blob/master/docs/index.rst"
       ]
     },
     {
@@ -444,6 +456,17 @@
       ]
     },
     {
+      "name": "Bitstream Charter Font License",
+      "licenseId": "Bitstream-Charter",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Charter#License_Text",
+        "https://raw.githubusercontent.com/blackhole89/notekit/master/data/fonts/Charter%20license.txt"
+      ]
+    },
+    {
       "name": "Bitstream Vera Font License",
       "licenseId": "Bitstream-Vera",
       "isDeprecatedLicenseId": false,
@@ -503,6 +526,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ]
+    },
+    {
+      "name": "Brian Gladman 3-Clause License",
+      "licenseId": "Brian-Gladman-3-Clause",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-clib/blob/master/sha1/brg_endian.h"
       ]
     },
     {
@@ -698,6 +731,46 @@
       "isFsfLibre": false,
       "seeAlso": [
         "http://www.freebsd.org/copyright/license.html"
+      ]
+    },
+    {
+      "name": "BSD 4.3 RENO License",
+      "licenseId": "BSD-4.3RENO",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=libiberty/strcasecmp.c;h=131d81c2ce7881fa48c363dc5bf5fb302c61ce0b;hb=HEAD"
+      ]
+    },
+    {
+      "name": "BSD 4.3 TAHOE License",
+      "licenseId": "BSD-4.3TAHOE",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/389ds/389-ds-base/blob/main/ldap/include/sysexits-compat.h#L15"
+      ]
+    },
+    {
+      "name": "BSD Advertising Acknowledgement License",
+      "licenseId": "BSD-Advertising-Acknowledgement",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/python-excel/xlrd/blob/master/LICENSE#L33"
+      ]
+    },
+    {
+      "name": "BSD with Attribution and HPND disclaimer",
+      "licenseId": "BSD-Attribution-HPND-disclaimer",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/cyrusimap/cyrus-sasl/blob/master/COPYING"
       ]
     },
     {
@@ -1074,6 +1147,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+      ]
+    },
+    {
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
+      "licenseId": "CC-BY-NC-SA-2.0-DE",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/de/legalcode"
       ]
     },
     {
@@ -1490,6 +1573,16 @@
       ]
     },
     {
+      "name": "CFITSIO License",
+      "licenseId": "CFITSIO",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/f_user/node9.html"
+      ]
+    },
+    {
       "name": "Checkmk License",
       "licenseId": "checkmk",
       "isDeprecatedLicenseId": false,
@@ -1508,6 +1601,26 @@
       "seeAlso": [
         "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
         "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ]
+    },
+    {
+      "name": "Clips License",
+      "licenseId": "Clips",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/DrItanium/maya/blob/master/LICENSE.CLIPS"
+      ]
+    },
+    {
+      "name": "CMU Mach License",
+      "licenseId": "CMU-Mach",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.cs.cmu.edu/~410/licenses.html"
       ]
     },
     {
@@ -1589,6 +1702,18 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ]
+    },
+    {
+      "name": "Cornell Lossless JPEG License",
+      "licenseId": "Cornell-Lossless-JPEG",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_lossless_jpeg.cpp#16",
+        "https://www.mssl.ucl.ac.uk/~mcrw/src/20050920/proto.h",
+        "https://gitlab.freedesktop.org/libopenraw/libopenraw/blob/master/lib/ljpegdecompressor.cpp#L32"
       ]
     },
     {
@@ -2538,6 +2663,16 @@
       ]
     },
     {
+      "name": "Graphics Gems License",
+      "licenseId": "Graphics-Gems",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/erich666/GraphicsGems/blob/master/LICENSE.md"
+      ]
+    },
+    {
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "isDeprecatedLicenseId": false,
@@ -2569,6 +2704,16 @@
       ]
     },
     {
+      "name": "Hewlett-Packard 1986 License",
+      "licenseId": "HP-1986",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/hppa/memchr.S;h=1cca3e5e8867aa4bffef1f75a5c1bba25c0c441e;hb=HEAD#l2"
+      ]
+    },
+    {
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "isDeprecatedLicenseId": false,
@@ -2579,6 +2724,27 @@
       ]
     },
     {
+      "name": "HPND with US Government export control warning",
+      "licenseId": "HPND-export-US",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.kermitproject.org/ck90.html#source"
+      ]
+    },
+    {
+      "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+      "licenseId": "HPND-Markus-Kuhn",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c",
+        "https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=readline/readline/support/wcwidth.c;h=0f5ec995796f4813abbcf4972aec0378ab74722a;hb=HEAD#l55"
+      ]
+    },
+    {
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "isDeprecatedLicenseId": false,
@@ -2586,6 +2752,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19"
+      ]
+    },
+    {
+      "name": "HPND sell variant with MIT disclaimer",
+      "licenseId": "HPND-sell-variant-MIT-disclaimer",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/README"
       ]
     },
     {
@@ -2619,6 +2795,18 @@
       ]
     },
     {
+      "name": "IEC    Code Components End-user licence agreement",
+      "licenseId": "IEC-Code-Components-EULA",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.iec.ch/webstore/custserv/pdf/CC-EULA.pdf",
+        "https://www.iec.ch/CCv1",
+        "https://www.iec.ch/copyright"
+      ]
+    },
+    {
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "isDeprecatedLicenseId": false,
@@ -2626,6 +2814,16 @@
       "isFsfLibre": true,
       "seeAlso": [
         "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev=1.2"
+      ]
+    },
+    {
+      "name": "Independent JPEG Group License - short",
+      "licenseId": "IJG-short",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/ljpg/"
       ]
     },
     {
@@ -2753,6 +2951,16 @@
       ]
     },
     {
+      "name": "JPL Image Use Policy",
+      "licenseId": "JPL-image",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.jpl.nasa.gov/jpl-image-use-policy"
+      ]
+    },
+    {
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "isDeprecatedLicenseId": false,
@@ -2770,6 +2978,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "http://www.json.org/license.html"
+      ]
+    },
+    {
+      "name": "Kazlib License",
+      "licenseId": "Kazlib",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/kazlib.git/tree/except.c?id=0062df360c2d17d57f6af19b0e444c51feb99036"
       ]
     },
     {
@@ -2874,7 +3092,7 @@
       ]
     },
     {
-      "name": "GNU Library General Public License v2.1 or later",
+      "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "isDeprecatedLicenseId": true,
       "isOsiApproved": true,
@@ -3069,6 +3287,21 @@
       ]
     },
     {
+      "name": "Common Lisp LOOP License",
+      "licenseId": "LOOP",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://gitlab.com/embeddable-common-lisp/ecl/-/blob/develop/src/lsp/loop.lsp",
+        "http://git.savannah.gnu.org/cgit/gcl.git/tree/gcl/lsp/gcl_loop.lsp?h=Version_2_6_13pre",
+        "https://sourceforge.net/p/sbcl/sbcl/ci/master/tree/src/code/loop.lisp",
+        "https://github.com/cl-adams/adams/blob/master/LICENSE.md",
+        "https://github.com/blakemcbride/eclipse-lisp/blob/master/lisp/loop.lisp",
+        "https://gitlab.common-lisp.net/cmucl/cmucl/-/blob/master/src/code/loop.lisp"
+      ]
+    },
+    {
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "isDeprecatedLicenseId": false,
@@ -3170,6 +3403,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ]
+    },
+    {
+      "name": "Martin Birgmeier License",
+      "licenseId": "Martin-Birgmeier",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/Perl/perl5/blob/blead/util.c#L6136"
       ]
     },
     {
@@ -3279,6 +3522,16 @@
         "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
         "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
         "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
+      ]
+    },
+    {
+      "name": "MIT Tom Wu Variant",
+      "licenseId": "MIT-Wu",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/chromium/octane/blob/master/crypto.js"
       ]
     },
     {
@@ -3779,6 +4032,16 @@
       ]
     },
     {
+      "name": "OFFIS License",
+      "licenseId": "OFFIS",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/dicom/README"
+      ]
+    },
+    {
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "isDeprecatedLicenseId": false,
@@ -4083,6 +4346,17 @@
       ]
     },
     {
+      "name": "OpenPBS v2.3 Software License",
+      "licenseId": "OpenPBS-2.3",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/adaptivecomputing/torque/blob/master/PBS_License.txt",
+        "https://www.mcs.anl.gov/research/projects/openpbs/PBS_License.txt"
+      ]
+    },
+    {
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "isDeprecatedLicenseId": false,
@@ -4343,6 +4617,16 @@
         "http://doc.qt.nokia.com/3.3/license.html",
         "https://opensource.org/licenses/QPL-1.0",
         "https://doc.qt.io/archives/3.3/license.html"
+      ]
+    },
+    {
+      "name": "Q Public License 1.0 - INRIA 2004 variant",
+      "licenseId": "QPL-1.0-INRIA-2004",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/maranget/hevea/blob/master/LICENSE"
       ]
     },
     {
@@ -4609,6 +4893,16 @@
       ]
     },
     {
+      "name": "snprintf License",
+      "licenseId": "snprintf",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/master/openbsd-compat/bsd-snprintf.c#L2"
+      ]
+    },
+    {
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "isDeprecatedLicenseId": false,
@@ -4687,7 +4981,7 @@
       "isOsiApproved": false,
       "isFsfLibre": true,
       "seeAlso": [
-        "http://www.smlnj.org//license.html"
+        "https://www.smlnj.org/license.html"
       ]
     },
     {
@@ -4701,6 +4995,17 @@
       ]
     },
     {
+      "name": "SunPro License",
+      "licenseId": "SunPro",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_acosh.c",
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_lgammal.c"
+      ]
+    },
+    {
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "isDeprecatedLicenseId": false,
@@ -4708,6 +5013,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/SWL"
+      ]
+    },
+    {
+      "name": "Symlinks License",
+      "licenseId": "Symlinks",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://www.mail-archive.com/debian-bugs-rc@lists.debian.org/msg11494.html"
       ]
     },
     {
@@ -4772,6 +5087,37 @@
       ]
     },
     {
+      "name": "Time::ParseDate License",
+      "licenseId": "TPDL",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://metacpan.org/pod/Time::ParseDate#LICENSE"
+      ]
+    },
+    {
+      "name": "THOR Public License 1.0",
+      "licenseId": "TPL-1.0",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:ThorPublicLicense"
+      ]
+    },
+    {
+      "name": "Text-Tabs+Wrap License",
+      "licenseId": "TTWL",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TTWL",
+        "https://github.com/ap/Text-Tabs/blob/master/lib.modern/Text/Tabs.pm#L148"
+      ]
+    },
+    {
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "isDeprecatedLicenseId": false,
@@ -4789,6 +5135,16 @@
       "isFsfLibre": false,
       "seeAlso": [
         "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ]
+    },
+    {
+      "name": "UCAR License",
+      "licenseId": "UCAR",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/Unidata/UDUNITS-2/blob/master/COPYRIGHT"
       ]
     },
     {
@@ -4913,6 +5269,16 @@
       ]
     },
     {
+      "name": "w3m License",
+      "licenseId": "w3m",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://github.com/tats/w3m/blob/master/COPYING"
+      ]
+    },
+    {
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "isDeprecatedLicenseId": false,
@@ -5001,6 +5367,16 @@
       "isFsfLibre": true,
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ]
+    },
+    {
+      "name": "xlock License",
+      "licenseId": "xlock",
+      "isDeprecatedLicenseId": false,
+      "isOsiApproved": false,
+      "isFsfLibre": false,
+      "seeAlso": [
+        "https://fossies.org/linux/tiff/contrib/ras/ras2tif.c"
       ]
     },
     {
@@ -5146,5 +5522,5 @@
       ]
     }
   ],
-  "releaseDate": "2023-02-16"
+  "releaseDate": "2023-02-23"
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -33,6 +33,7 @@ export type FullSpdxParseResult = {
             .replace(/(?<!\s)\s+and\s+/i, ' AND ')    // fix lowercase keywords
             .replace(/(?<!\s)\s+or\s+/i, ' OR ')      // fix lowercase keywords
             .replace(/(?<!\s)\s+with\s+/i, ' WITH ')  // fix lowercase keywords
+            .replace(/\s+[wW]\//, ' WITH ')           // expand "w/" shorthand for "WITH"
     }
     return cleanedInput
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -113,7 +113,7 @@ const findNameBasedMatch = (text: string): License|undefined => {
         // If the license identifier looks like "Mozilla Public License 2.0 (MPL 2.0)", try
         // to parse the identifier in the parenthesis. If that fails, we'll try to see if the
         // parenthesized text is an exact match against a license name.
-        const potentialIdentifier = (preparedInput?.match(/\s\((.*)\)$/))?.[1]
+        const potentialIdentifier = (preparedInput?.match(/\s\((.+?)\)$/))?.[1]
         if (potentialIdentifier) {
             // check if it's an SPDX identifier
             const candidateResult = parseSpdxExpressionWithDetails(potentialIdentifier, strictSyntax)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -35,7 +35,7 @@ export type FullSpdxParseResult = {
             .replace(/(?<!\s)\s+and\s+/i, ' AND ')    // fix lowercase keywords
             .replace(/(?<!\s)\s+or\s+/i, ' OR ')      // fix lowercase keywords
             .replace(/(?<!\s)\s+with\s+/i, ' WITH ')  // fix lowercase keywords
-            .replace(/\s+[wW]\//, ' WITH ')           // expand "w/" shorthand for "WITH"
+            .replace(/\s[wW]\/\s?/, ' WITH ')           // expand "w/" shorthand for "WITH"
     }
     return cleanedInput
 }
@@ -105,7 +105,7 @@ const findNameBasedMatch = (text: string): License|undefined => {
         }
 
         // If the license identifier happens to be an exact match of a license name...
-        let nameBasedMatch = findNameBasedMatch(preparedInput)
+        const nameBasedMatch = findNameBasedMatch(preparedInput)
         if (nameBasedMatch) {
             return parseSpdxExpressionWithDetails(nameBasedMatch.licenseId, strictSyntax)
         }
@@ -113,10 +113,10 @@ const findNameBasedMatch = (text: string): License|undefined => {
         // If the license identifier looks like "Mozilla Public License 2.0 (MPL 2.0)", try
         // to parse the identifier in the parenthesis. If that fails, we'll try to see if the
         // parenthesized text is an exact match against a license name.
-        let potentialIdentifier = (preparedInput?.match(/\s+\((.*)\)$/))?.[1]
+        const potentialIdentifier = (preparedInput?.match(/\s\((.*)\)$/))?.[1]
         if (potentialIdentifier) {
             // check if it's an SPDX identifier
-            const candidateResult = parseSpdxExpressionWithDetails(potentialIdentifier, true)
+            const candidateResult = parseSpdxExpressionWithDetails(potentialIdentifier, strictSyntax)
             if (!candidateResult.error && candidateResult.expression && validate(candidateResult.input).valid) {
                 return candidateResult
             }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,7 +1,7 @@
 import { parse as parseWithStrictParser, StrictParserResult } from './strict_parser'
 import { parse as parseWithLiberalParser, LiberalParserResult } from './liberal_parser'
 import { ParsedSpdxExpression, ConjunctionInfo, LicenseInfo, LicenseRef } from './types'
-import { fixDashedLicenseInfo } from '../licenses'
+import { fixDashedLicenseInfo, licenses } from '../licenses'
 
 
 export { ParsedSpdxExpression, ConjunctionInfo, LicenseInfo, LicenseRef }
@@ -94,6 +94,12 @@ export function parse(input: string, strictSyntax: boolean = false) : ParsedSpdx
         // awareness of deviations from the SPDX specification
         if (!liberalResult.error) {
             return liberalResult
+        }
+
+        // If the license identifier happens to be an exact match of a license name...
+        let nameBasedMatch = licenses.licenses.find(x => x.name === preparedInput)
+        if (nameBasedMatch) {
+            return parseSpdxExpressionWithDetails(nameBasedMatch.licenseId, strictSyntax)
         }
     }
 

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -522,3 +522,34 @@ describe('Special cases', () => {
         })
     })
 })
+
+describe('Parenthesized scenarios', () => {
+
+    describe('Long form exact-name-match followed by a valid (IDENTIFIER-1.2.3)', () => {
+        it('tries to match the parenthesized identifier first', () => {
+            expect(parse('Mozilla Public License 2.0 (Apache-2.0)')).toStrictEqual({ license: 'Apache-2.0' })
+        })
+    })
+
+    describe('Long form followed by a valid (IDENTIFIER-1.2.3)', () => {
+        it('detects parenthesized identifier in liberal mode', () => {
+            expect(() => parse('Mozilla Public License 2.0 (MPL 2.0)', true)).toThrow()
+            expect(parse('Mozilla Public License 2.0 (MPL 2.0)', false)).toStrictEqual({ license: 'MPL-2.0' })
+            expect(parse('GNU Lesser General Public License v3 or later (LGPLv3+)', false)).toStrictEqual({ license: 'LGPL-3.0-or-later' })
+            expect(parse('Does not have to be valid name here (Apache-2.0)', false)).toStrictEqual({ license: 'Apache-2.0' })
+        })
+
+        it('detects parenthesized exact name match in liberal mode', () => {
+            expect(() => parse('It will throw in strict mode (Mozilla Public License 2.0)', true)).toThrow()
+            expect(() => parse('It will throw unless there is an exact match (This is not an exact match)', false)).toThrow()
+            expect(parse('Some freeform text here (Mozilla Public License 2.0)', false)).toStrictEqual({ license: 'MPL-2.0' })
+            expect(parse('Blah blah blah blah (GNU Lesser General Public License v3.0 or later)', false)).toStrictEqual({ license: 'LGPL-3.0-or-later' })
+        })
+
+        it('ignores multiple parenthesized identifiers even in liberal mode', () => {
+            expect(() => parse('Licensed the GPL (GPLv3+) or the Modified BSD License (BSD-3-Clause)', false)).toThrow()
+            expect(parse('Licensed under the GPL (GPLv3+)', false)).toStrictEqual({ license: 'GPL-3.0-or-later' })
+            expect(parse('Licensed under the Modified BSD License (BSD-3-Clause)', false)).toStrictEqual({ license: 'BSD-3-Clause' })
+        })
+    })
+})

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -5,7 +5,6 @@ const scenario = (name: string, body: (name: string) => void) => it(name, () => 
     body(name)
 })
 
-
 describe('GPL family of expressions with a "+" suffix', () => {
     describe('"AGPL-3.0+" is interpreted as "AGPL-3.0-or-later"', () => {
 
@@ -44,6 +43,7 @@ describe('Deprecated "default" GPL versions are coerced into their non-deprecate
             expect(parse('LGPL-3.0')).toStrictEqual({ license: 'LGPL-3.0-only' })
             expect(parse('LGPL-3.0-or-later')).toStrictEqual({ license: 'LGPL-3.0-or-later' })
             expect(parse('LGPL-3.0+')).toStrictEqual({ license: 'LGPL-3.0-or-later' })
+            expect(parse('LGPLv3+')).toStrictEqual({ license: 'LGPL-3.0-or-later' })
         })
     })
 

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -5,6 +5,19 @@ const scenario = (name: string, body: (name: string) => void) => it(name, () => 
     body(name)
 })
 
+describe('Exact matches of license names', () => {
+
+    it('are accepted/corrected in liberal mode', () => {
+        expect(parse('Mozilla Public License 2.0', false)).toStrictEqual({ license: 'MPL-2.0' })
+        expect(parse('The Unlicense', false)).toStrictEqual({ license: 'Unlicense' })
+    })
+
+    it('are not accepted/corrected in strict mode', () => {
+        expect(() => parse('Mozilla Public License 2.0', true)).toThrow()
+        expect(() => parse('The Unlicense', true)).toThrow()
+    })
+})
+
 describe('GPL family of expressions with a "+" suffix', () => {
     describe('"AGPL-3.0+" is interpreted as "AGPL-3.0-or-later"', () => {
 

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -316,6 +316,54 @@ describe('Expressions with slight errors', () => {
 
     describe('common misspellings', () => {
 
+        describe('of "WITH" as "w/"', () => {
+
+            it('"w/" is corrected when strictSyntax = false', () => {
+                const expression = 'GPL-3.0-only w/ Autoconf-exception-2.0'
+                expect(() => parse(expression, true)).toThrowError()
+                expect(parse(expression, false)).toMatchObject({
+                    license: 'GPL-3.0-only',
+                    exception: 'Autoconf-exception-2.0'
+                })
+            })
+
+            it('"W/" is corrected when strictSyntax = false', () => {
+                const expression = 'GPLv3+ W/ autoconf-exception-2.0'
+                expect(() => parse(expression, true)).toThrowError()
+                expect(parse(expression, false)).toMatchObject({
+                    license: 'GPL-3.0-or-later',
+                    exception: 'Autoconf-exception-2.0'
+                })
+            })
+
+            it('"w/" is corrected even when there is no whitespace before a valid exception', () => {
+                const expression = 'GPL-3.0-only w/autoconf-exception-2.0'
+                expect(() => parse(expression, true)).toThrowError()
+                expect(parse(expression, false)).toMatchObject({
+                    license: 'GPL-3.0-only',
+                    exception: 'Autoconf-exception-2.0'
+                })
+            })
+
+            it('"w/" is corrected even when there is no whitespace before an unknown exception', () => {
+                const expression = 'GPL-3.0-only w/not an exception'
+                expect(() => parse(expression, true)).toThrowError()
+                expect(parse(expression, false)).toMatchObject({
+                    license: 'GPL-3.0-only',
+                    exception: 'not an exception'
+                })
+            })
+
+            it('"w/" is not corrected even in liberal mode when there is no license identifier before it', () => {
+                expect(() => parse('w/whatever', true)).toThrowError()
+                expect(() => parse('w/whatever', false)).toThrowError()
+                expect(() => parse(' w/ whatever', true)).toThrowError()
+                expect(() => parse(' w/ whatever', false)).toThrowError()
+                expect(() => parse('XXXw/whatever', true)).toThrowError()
+                expect(() => parse('XXXw/whatever', false)).toThrowError()
+            })
+        })
+
         describe('of license exceptions', () => {
 
             it('"autoconf exception 2.0" or "autoconf exception version 2" is corrected to Autoconf-exception-2.0', () => {

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -94,6 +94,8 @@ describe('Examples passing validation', () => {
         describe('without exception', () => {
             shouldPassValidation('Apache-2.0')
             shouldPassValidation('MIT')
+            shouldPassValidation('PSF-2.0')
+            shouldPassValidation('MPL-2.0')
             shouldPassValidation('GPL-2.0-or-later')
             shouldPassValidation('LGPL-2.0+')
         })


### PR DESCRIPTION
This PR expands liberal mode to detect license names/identifiers in the following scenarios:

1. From "Some freeform text here (Mozilla Public License 2.0)" we'll pick up that "Mozilla Public License 2.0" is the exact name for MPL-2.0 in the SPDX data.
2. From "Blah Blah Blah (MIT)" we'll recognize that "MIT" is a valid SPDX identifier in the SPDX data.    

However, if it's a longer text that contains multiple parenthesized license names or identifiers, even exact matches, we won't make assumptions about whether it's an "AND" or an "OR".