### PR TITLE
Fix problems noticed thanks to new additions to source data

### DIFF
--- a/scripts/codegen-license-update.js
+++ b/scripts/codegen-license-update.js
@@ -28,10 +28,15 @@ const downloadJSON = async (url) => {
                 if (err) {
                     console.warn(`Could not download JSON from ${url} - ${err}`)
                     resolve('{}')
+                } else {
+                    resolve(fs.readFileSync(tmpFilePath))
                 }
-                else { resolve(fs.readFileSync(tmpFilePath)) }
             }
-            pipeline(response, fs.createWriteStream(tmpFilePath), errorHandler)
+            if (response.statusCode === 200) {
+                pipeline(response, fs.createWriteStream(tmpFilePath), errorHandler)
+            } else {
+                errorHandler(`HTTP ${response.statusCode} ${response.statusMessage ? response.statusMessage : ''}`.trimEnd())
+            }
         })
     })
     try {

--- a/scripts/codegen-license-update.js
+++ b/scripts/codegen-license-update.js
@@ -100,11 +100,16 @@ const updateFileFromURL = async (destinationFilePath, sourceUrl, entryListKey, d
         console.log(`${destinationFilePath} already has version ${latestVersion} from ${sourceUrl} --> skip update`)
     } else {
         console.log(`Update available (from ${localVersion} to ${latestVersion}) --> updating ${entryListKey}`)
-        const urls = json[entryListKey].map(detailsUrlMapper)
+        const licensesInMainDocument = json[entryListKey]
+        const urls = licensesInMainDocument.map(detailsUrlMapper)
         const details = await downloadManyJSONFiles(urls)
-        json[entryListKey] = details.filter(x => !!x && !x.error).map(detailsObjectMapper)
+        json[entryListKey] = details.filter(x => !!x && !x.error).map(detailsObjectMapper).filter(x => !!x)
         fs.writeFileSync(destinationFilePath, JSON.stringify(json, null, 2))
         console.log(`Updated ${destinationFilePath} with version ${latestVersion} from ${sourceUrl}`)
+        const entriesWithMissingDetails = licensesInMainDocument.filter(x => !details.find(d => d.licenseId === x.licenseId))
+        if (entriesWithMissingDetails.length > 0) {
+            console.warn(`Some entries (${entriesWithMissingDetails.length}) were missing from the details files. Got ${json[entryListKey].length} out of ${licensesInMainDocument.length} but failed on the following entries:\n${JSON.stringify(entriesWithMissingDetails, null, 2)}`)
+        }
     }
 }
 

--- a/src/codegen/exceptions.json
+++ b/src/codegen/exceptions.json
@@ -1,5 +1,5 @@
 {
-  "licenseListVersion": "db6f092",
+  "licenseListVersion": "9ec9145",
   "exceptions": [
     {
       "licenseExceptionId": "389-exception",
@@ -770,5 +770,5 @@
       "relatedLicenses": []
     }
   ],
-  "releaseDate": "2024-01-25"
+  "releaseDate": "2024-02-01"
 }

--- a/src/codegen/licenses.json
+++ b/src/codegen/licenses.json
@@ -1,5 +1,5 @@
 {
-  "licenseListVersion": "db6f092",
+  "licenseListVersion": "9ec9145",
   "licenses": [
     {
       "name": "BSD Zero Clause License",
@@ -6168,5 +6168,5 @@
       ]
     }
   ],
-  "releaseDate": "2024-01-25"
+  "releaseDate": "2024-02-01"
 }

--- a/src/licenses/index.ts
+++ b/src/licenses/index.ts
@@ -159,24 +159,14 @@ const fixExceptionid = (id: string, associatedLicense?: string|undefined): strin
         return combo.slice(1).reduce((prev, curr) => curr(prev), initialValue)
     }))]
     const matchedIds = [ ...new Set(potentialIdentifiers.map(mapExceptionId).filter(id => !!id)) ]
-    if (matchedIds.length > 1) console.warn(`fixExceptionId(${JSON.stringify(id)}) found ${matchedIds.length} matches through mutations: ${JSON.stringify(matchedIds)}`)
 
     if (matchedIds.length === 0 && !id.match(/\d+(\.\d+)*$/)) {
-        // TODO: if the identifier to fix looks like "autoconf exception" without a "2.0" or "-2.0" suffix,
+        // If the identifier to fix looks like "autoconf exception" without a "2.0" or "-2.0" suffix,
         // try to look for partial matches in the list of known exceptions (e.g. "autoconf-exception-2.0" and "autoconf-exception-3.0")
         const prefixMatchedIds = [ ...new Set(potentialIdentifiers.flatMap(knownExceptionIdentifiersStartingWith)) ]
-        if (id === 'Autoconf exception' || id === 'Autoconf-exception') console.warn(`fixExceptionId(${JSON.stringify(id)}) found no matches through mutations, trying prefix matching with potentialIdentifiers: ${JSON.stringify(potentialIdentifiers)} => ${JSON.stringify(prefixMatchedIds)}`)
-        // if (prefixMatchedIds.length > 1) console.warn(`fixExceptionId(${JSON.stringify(id)}) found ${prefixMatchedIds.length} matches through prefix matching: ${JSON.stringify(prefixMatchedIds)}`)
         if (prefixMatchedIds.length > 1 && associatedLicense) {
-            const selected = selectBestMatchByAssociation(prefixMatchedIds, associatedLicense)
-            if (id === 'Autoconf exception' || id === 'Autoconf-exception') {
-                console.warn(`fixExceptionId(${JSON.stringify(id)}, ${JSON.stringify(associatedLicense)}) selected best match by association as ${JSON.stringify(selected)} from ${JSON.stringify(prefixMatchedIds)}`)
-            }
-            return selected
+            return selectBestMatchByAssociation(prefixMatchedIds, associatedLicense)
         } else {
-            if (id === 'Autoconf exception' || id === 'Autoconf-exception') {
-                console.warn(`fixExceptionId(${JSON.stringify(id)}, ${JSON.stringify(associatedLicense)}) got ${prefixMatchedIds.length} prefix-matched identifiers. Returning ${JSON.stringify(prefixMatchedIds[0])}`)
-            }
             return prefixMatchedIds[0]
         }
     }

--- a/src/licenses/index.ts
+++ b/src/licenses/index.ts
@@ -8,6 +8,7 @@ export { licenses, Licenses, License, exceptions, Exceptions, Exception }
 
 type MapOfIds = {
     get: (id: string) => string | undefined,
+    list: () => string[]
 }
 
 const idEndsWithVersionNumber = (id: string): boolean => {
@@ -50,7 +51,8 @@ const createMapOfIds = (ids: string[]): MapOfIds => {
     const get = (id: string): string | undefined => {
         return getExactMatch(id) || getCaseInsensitiveMatch(id) || getFuzzyMatch(id) || getSingleVersionMatch(id)
     }
-    return { get } as MapOfIds
+    const list = (): string[] => listOfOfficialIds
+    return { get, list } as MapOfIds
 }
 
 const mapOfKnownLicenses: MapOfIds = createMapOfIds(licenses.licenses.map(lic => lic.licenseId))
@@ -92,7 +94,9 @@ const aliasesForLicenseIds: Map<string, string> = ((): Map<string, string> => {
 const aliasesForExceptions: Map<string, string> = ((): Map<string, string> => {
     const mapOfAliases = new Map<string, string>()
     mapOfAliases.set('qwt license 1.0', 'Qwt-exception-1.0')
+    mapOfAliases.set('qwt license 1', 'Qwt-exception-1.0')
     mapOfAliases.set('cpe', 'Classpath-exception-2.0')
+    mapOfAliases.set('gnu cpe', 'Classpath-exception-2.0')
     return mapOfAliases
 })()
 
@@ -132,7 +136,14 @@ const mapExceptionId = (id: string): string | undefined => {
     return mapOfKnownExceptions.get(id.toLowerCase())
 }
 
-const fixExceptionid = (id: string): string | undefined => {
+const knownExceptionIdentifiersStartingWith = (prefix: string): string[] => {
+    const lowercasedPrefix = prefix.toLowerCase()
+    return mapOfKnownExceptions.list()
+        .filter(id => id.toLowerCase().startsWith(lowercasedPrefix))                    // Must start with the prefix (ignoring case)
+        .filter(id => id.substring(lowercasedPrefix.length).match(/^\-?\d+(\.\d+)*$/))  // The suffix must be strictly a version number like "[prefix]-2.0" or "[prefix]3.0"
+}
+
+const fixExceptionid = (id: string, associatedLicense?: string|undefined): string | undefined => {
     type Mutation = (s: string) => string
 
     const mutations: Mutation[] = [
@@ -143,49 +154,104 @@ const fixExceptionid = (id: string): string | undefined => {
         (id: string): string => id.replace(/(.+)\s+\(.+?\)((v|version )?\d\.\d)?/gi, '$1$2'),
     ]
     const permutations = permutationsOf<Mutation>(mutations, 3)
-    const potentialIdentifiers = permutations.map((combo: Mutation[]): string => {
+    const potentialIdentifiers = [...new Set(permutations.map((combo: Mutation[]): string => {
         const initialValue = combo[0](id)
         return combo.slice(1).reduce((prev, curr) => curr(prev), initialValue)
-    })
+    }))]
     const matchedIds = [ ...new Set(potentialIdentifiers.map(mapExceptionId).filter(id => !!id)) ]
     if (matchedIds.length > 1) console.warn(`fixExceptionId(${JSON.stringify(id)}) found ${matchedIds.length} matches through mutations: ${JSON.stringify(matchedIds)}`)
+
+    if (matchedIds.length === 0 && !id.match(/\d+(\.\d+)*$/)) {
+        // TODO: if the identifier to fix looks like "autoconf exception" without a "2.0" or "-2.0" suffix,
+        // try to look for partial matches in the list of known exceptions (e.g. "autoconf-exception-2.0" and "autoconf-exception-3.0")
+        const prefixMatchedIds = [ ...new Set(potentialIdentifiers.flatMap(knownExceptionIdentifiersStartingWith)) ]
+        if (id === 'Autoconf exception' || id === 'Autoconf-exception') console.warn(`fixExceptionId(${JSON.stringify(id)}) found no matches through mutations, trying prefix matching with potentialIdentifiers: ${JSON.stringify(potentialIdentifiers)} => ${JSON.stringify(prefixMatchedIds)}`)
+        // if (prefixMatchedIds.length > 1) console.warn(`fixExceptionId(${JSON.stringify(id)}) found ${prefixMatchedIds.length} matches through prefix matching: ${JSON.stringify(prefixMatchedIds)}`)
+        if (prefixMatchedIds.length > 1 && associatedLicense) {
+            const selected = selectBestMatchByAssociation(prefixMatchedIds, associatedLicense)
+            if (id === 'Autoconf exception' || id === 'Autoconf-exception') {
+                console.warn(`fixExceptionId(${JSON.stringify(id)}, ${JSON.stringify(associatedLicense)}) selected best match by association as ${JSON.stringify(selected)} from ${JSON.stringify(prefixMatchedIds)}`)
+            }
+            return selected
+        } else {
+            if (id === 'Autoconf exception' || id === 'Autoconf-exception') {
+                console.warn(`fixExceptionId(${JSON.stringify(id)}, ${JSON.stringify(associatedLicense)}) got ${prefixMatchedIds.length} prefix-matched identifiers. Returning ${JSON.stringify(prefixMatchedIds[0])}`)
+            }
+            return prefixMatchedIds[0]
+        }
+    }
+
     return matchedIds[0]
 }
 
-const mapExceptionIdByAssociatedLicense = (id: string, associatedLicense?: string): string|undefined => {
-    const expandLicenses = (identifiers: string[]): string[] => {
-        const expandedList = [...identifiers]
-        identifiers.forEach(id => {
-            if (id.match(/[^\+]\+$/)) {
-                expandedList.push(id.replace(/\+$/, '-or-later'))
-                expandedList.push(id.replace(/\+$/, ''))
-            } else if (id.match(/-or-later$/)) {
-                expandedList.push(id.replace(/-or-later$/, ''))
-            } else if (id.match(/-only$/)) {
+type PartialExpandLicenseOptions = {
+    expandScope?: boolean
+}
+
+type FullExpandLicenseOptions = {
+    expandScope: boolean
+}
+
+export const expandLicenses = (identifiers: string[], providedOptions?: PartialExpandLicenseOptions): string[] => {
+    const defaultOptions: FullExpandLicenseOptions = { expandScope: false }
+    const effectiveOptions: FullExpandLicenseOptions = { ...defaultOptions, ...providedOptions }
+    const expandedList = [...identifiers]
+    identifiers.forEach(id => {
+        if (id.match(/[^\+]\+$/)) {
+            expandedList.push(id.replace(/\+$/, '-or-later'))
+            expandedList.push(id.replace(/\+$/, '-and-later'))
+            expandedList.push(id.replace(/\+$/, ''))
+        } else if (id.match(/-(or|and)-later$/)) {
+            expandedList.push(id.replace(/-or-later$/, '-and-later'))
+            expandedList.push(id.replace(/-and-later$/, '-or-later'))
+            expandedList.push(id.replace(/-(or|and)-later$/, ''))
+        } else if (id.match(/-only$/)) {
+            if (effectiveOptions.expandScope) {
                 expandedList.push(id.replace(/-only$/, ''))
-            } else if (id.match(/[AL]?GPL\-\d\.\d$/)) {
-                expandedList.push(`${id}-only`)
-                expandedList.push(`${id}-or-later`)
             }
-        })
-        return expandedList
-    }
-    if (associatedLicense) {
-        const possibleMatches = exceptions.exceptions.filter(e => {
-            const hasRelation = () => {
-                const relatedLicenses = expandLicenses(e.relatedLicenses)
-                return relatedLicenses.length === 0 || relatedLicenses.includes(associatedLicense)
-            }
-            const looksSimilar = () => {
-                return e.licenseExceptionId.toLowerCase().startsWith(id.toLowerCase())
-            }
-            return looksSimilar() && hasRelation()
-        }).map(e => e.licenseExceptionId).sort()
-        if (possibleMatches.length > 0) {
-            return possibleMatches[0]
+        } else if (id.match(/[AL]?GPL\-\d\.\d$/)) {
+            expandedList.push(`${id}-only`)
+            expandedList.push(`${id}-or-later`)
+            expandedList.push(`${id}-and-later`)
         }
+    })
+    return [...new Set(expandedList)].sort()
+}
+
+const selectBestMatchByAssociation = (candidateExceptionIds: string[], associatedLicense: string): string => {
+    type StrengthOfRelation = { strength: number, exception: Exception }
+
+    const strengthOfRelation = (exception: Exception, license?: string): StrengthOfRelation => {
+        if (license) {
+            const stronglyRelatedLicenses = expandLicenses(exception.relatedLicenses, { expandScope: false })
+            if (stronglyRelatedLicenses.includes(license)) return { strength: 2, exception }
+
+            const weaklyRelatedLicenses = expandLicenses(exception.relatedLicenses, { expandScope: true })
+            if (weaklyRelatedLicenses.includes(license)) return { strength: 1, exception }
+        }
+        return { strength: 0, exception }
     }
-    return undefined
+
+    const possibleMatches = candidateExceptionIds
+        .map(id => exceptions.exceptions.find(e => e.licenseExceptionId === id))
+        .filter(e => !!e).map(e => e as Exception)
+        .map(e => strengthOfRelation(e, associatedLicense))
+        .sort((a: StrengthOfRelation, b: StrengthOfRelation) => b.strength - a.strength)
+        .map(match => match.exception)
+
+    if (possibleMatches.length > 0) {
+        // In case there are multiple possible matches - typically because there are multiple
+        // versions of a given exception (e.g. "Bison-exception-1.24" and "Bison-exception-2.2")
+        // - we'll pick the last one, i.e. the most recent one:
+        if (possibleMatches.length > 1) {
+            const matchesAssociatedToLicense = possibleMatches.filter(e => expandLicenses(e.relatedLicenses).includes(associatedLicense))
+            if (matchesAssociatedToLicense.length > 0) {
+                return matchesAssociatedToLicense[0]?.licenseExceptionId
+            }
+        }
+        return possibleMatches[0]?.licenseExceptionId
+    }
+    return candidateExceptionIds[0]
 }
 
 /**
@@ -267,7 +333,11 @@ export function correctLicenseId(identifier: string, upgradeGPLVariants: boolean
 export function correctExceptionId(identifier: string, associatedLicense?: string): string {
 
     const removeExtras = (id: string): string => {
-        return id.replace(/^the\s+/i, '').replace(/\s+/, ' ')
+        return id.trim()
+            .replace(/^the\s+/i, '')
+            .replace(/\s+/, ' ')
+            .replace(/^gnu/, '')
+            .trim()
     }
 
     const applyAliases = (id: string): string => {
@@ -277,7 +347,7 @@ export function correctExceptionId(identifier: string, associatedLicense?: strin
     }
 
     const id = applyAliases(removeExtras(identifier))
-    return mapExceptionId(id) || fixExceptionid(id) || mapExceptionIdByAssociatedLicense(id, associatedLicense) || id
+    return mapExceptionId(id) || fixExceptionid(id, associatedLicense) || id
 }
 
 export function isKnownLicenseId(id: string): boolean {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -35,6 +35,7 @@ export type FullSpdxParseResult = {
             .replace(/(?<!\s)\s+or\s+/i, ' OR ')      // fix lowercase keywords
             .replace(/(?<!\s)\s+with\s+/i, ' WITH ')  // fix lowercase keywords
             .replace(/\s[wW]\/\s?/, ' WITH ')         // expand "w/" shorthand for "WITH"
+            .replace(/\splus\s/, ' AND ')             // replace the literal word "plus" with "AND"
     }
     return cleanedInput
 }

--- a/tests/corrections.exceptions.test.ts
+++ b/tests/corrections.exceptions.test.ts
@@ -1,0 +1,291 @@
+import { parse } from '../src'
+import { correctExceptionId, expandLicenses } from '../src/licenses'
+
+
+describe('correcting exception IDs through parse()', () => {
+
+    describe('Exact matches of known exception names', () => {
+
+        it('are accepted/corrected in liberal mode', () => {
+            expect(parse('GPL-2.0-only WITH Classpath exception 2.0', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+            expect(parse('GPL-2.0-or-later WITH Bison exception 2.2', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-or-later', exception: 'Bison-exception-2.2' })
+        })
+
+        /**
+         * @see https://spdx.github.io/spdx-spec/SPDX-license-expressions/#d2-case-sensitivity
+         */
+        it('are accepted/corrected in liberal mode ignoring case', () => {
+            expect(parse('GPL-2.0-only WITH ClasSpAth eXcepTion 2.0', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+            expect(parse('GPL-2.0-or-later WITH biSoN excEPTion 2.2', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-or-later', exception: 'Bison-exception-2.2' })
+        })
+
+        it('are accepted/corrected in liberal mode ignoring extra whitespace', () => {
+            expect(parse('GPL-2.0-only WITH   ClasSpAth   eXcepTion   2.0   ', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+            expect(parse('GPL-2.0-or-later WITH\t biSoN\texcEPTion\t\t\t2.2', { strictSyntax: false })).toStrictEqual({ license: 'GPL-2.0-or-later', exception: 'Bison-exception-2.2' })
+            expect(parse('Apache 2.0 WITH LLVM exception')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
+            expect(parse('apache 2.0 WITH  LLVM  Exception  ')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
+            expect(parse('apache 2.0 WITH llvm exception')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
+        })
+
+        it('are not accepted/corrected in strict mode', () => {
+            expect(() => parse('GPL-2.0-only WITH the classpath exception 2.0', { strictSyntax: true })).toThrow()
+            expect(() => parse('GPL-2.0-or-later WITH the bison exception 2.2', { strictSyntax: true })).toThrow()
+        })
+    })
+
+    it('misspelled exception that has no fix is left as-is', () => {
+        expect(parse('MIT WITH No Such Exception')).toStrictEqual({ license: 'MIT', exception: 'No Such Exception' })
+    })
+
+    describe('Expressions with nonexistent version numbers', () => {
+
+        describe('Are not corrected', () => {
+            it('GPL-2.0-only WITH Classpath-exception-4.5.6', () => {
+                expect(parse('GPL-2.0-only WITH Classpath-exception-4.5.6')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-4.5.6' })
+            })
+        })
+    })
+})
+
+describe('correcting exception IDs through correctExceptionId()', () => {
+
+    describe('misspelling that has no fix', () => {
+        it('renders the exception in its original form', () => {
+            expect(correctExceptionId('No Such Exception')).toStrictEqual('No Such Exception')
+        })
+    })
+
+    describe('common misspellings', () => {
+
+        describe('of Autoconf-exception-2.0', () => {
+            const misspellings =
+                ['autoconf exception 2.0', 'autoconf exception 2', 'autoconf exception version 2']
+                .flatMap((misspelling) => [misspelling, `the ${misspelling}`])
+            misspellings.forEach((misspelling) => {
+                it(JSON.stringify(misspelling), () => {
+                    expect(correctExceptionId(misspelling)).toStrictEqual('Autoconf-exception-2.0')
+                })
+            })
+        })
+
+        describe('of Classpath-exception-2.0', () => {
+            const misspellings =
+                ['classpath exception 2.0', 'classpath exception 2', 'classpath exception version 2', 'classpath exception version 2.0', 'CPE']
+                .flatMap((misspelling) => [misspelling, `GNU ${misspelling}`])
+                .flatMap((misspelling) => [misspelling, `the ${misspelling}`])
+            misspellings.forEach((misspelling) => {
+                it(JSON.stringify(misspelling), () => {
+                    expect(correctExceptionId(misspelling)).toStrictEqual('Classpath-exception-2.0')
+                })
+            })
+        })
+
+        describe('of Qwt-exception-1.0', () => {
+            const misspellings =
+                ['qwt exception 1.0', 'QWT exception 1', 'Qwt exception version 1.0']
+                .flatMap((misspelling) => [misspelling, misspelling.replace('exception', 'license')])
+                .flatMap((misspelling) => [misspelling, `the ${misspelling}`])
+            misspellings.forEach((misspelling) => {
+                it(JSON.stringify(misspelling), () => {
+                    expect(correctExceptionId(misspelling)).toStrictEqual('Qwt-exception-1.0')
+                })
+            })
+        })
+
+        describe('of u-boot-exception-2.0', () => {
+            const misspellings =
+                ['UBoot exception 2.0', 'UBoot exception 2']
+                .flatMap((misspelling) => [misspelling, `the ${misspelling}`])
+            misspellings.forEach((misspelling) => {
+                it(JSON.stringify(misspelling), () => {
+                    expect(correctExceptionId(misspelling)).toStrictEqual('u-boot-exception-2.0')
+                })
+            })
+        })
+
+    })
+
+    describe('ambiguity around omitted version', () => {
+
+        describe('is resolved based on associated license', () => {
+            const misspellings = ['Autoconf exception', 'autoconf-exception']
+            misspellings.forEach((misspelling) => {
+                ['GPL-2.0', 'GPL-2.0-only', 'GPL-2.0-or-later'].forEach((license) => {
+                    it(`"${license} WITH ${misspelling}" yields "Autoconf-exception-2.0"`, () => {
+                        expect(correctExceptionId(misspelling, license)).toStrictEqual('Autoconf-exception-2.0')
+                    })
+                });
+                ['GPL-3.0', 'GPL-3.0-only', 'GPL-3.0-or-later'].forEach((license) => {
+                    it(`"${license} WITH ${misspelling}" yields "Autoconf-exception-3.0"`, () => {
+                        expect(correctExceptionId(misspelling, license)).toStrictEqual('Autoconf-exception-3.0')
+                    })
+                });
+            })
+        })
+    })
+})
+
+describe('expandLicenses()', () => {
+    describe('GPL-2.0', () => {
+        it('with expandScope=true', () => {
+            expect(expandLicenses(['GPL-2.0'], { expandScope: true })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-only', 'GPL-2.0-or-later'])
+        })
+        it('with expandScope=false', () => {
+            expect(expandLicenses(['GPL-2.0'])).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-only', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0'], {})).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-only', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0'], { expandScope: undefined })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-only', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0'], { expandScope: false })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-only', 'GPL-2.0-or-later'])
+        })
+    })
+
+    describe('GPL-2.0+', () => {
+        it('with {expandScope:true}', () => {
+            expect(expandLicenses(['GPL-2.0+'], { expandScope: true })).toStrictEqual(['GPL-2.0', 'GPL-2.0+', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+        it('with omitted options', () => {
+            expect(expandLicenses(['GPL-2.0+'])).toStrictEqual(['GPL-2.0', 'GPL-2.0+', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+        it('with empty options', () => {
+            expect(expandLicenses(['GPL-2.0+'], {})).toStrictEqual(['GPL-2.0', 'GPL-2.0+', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+        it('with {expandScope:undefined}', () => {
+            expect(expandLicenses(['GPL-2.0+'], { expandScope: undefined })).toStrictEqual(['GPL-2.0', 'GPL-2.0+', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+        it('with {expandScope:false}', () => {
+            expect(expandLicenses(['GPL-2.0+'], { expandScope: false })).toStrictEqual(['GPL-2.0', 'GPL-2.0+', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+    })
+
+    describe('GPL-2.0-or-later', () => {
+        it('with expandScope=true', () => {
+            expect(expandLicenses(['GPL-2.0-or-later'], { expandScope: true })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+        it('with expandScope=false', () => {
+            expect(expandLicenses(['GPL-2.0-or-later'])).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0-or-later'], {})).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0-or-later'], { expandScope: undefined })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+            expect(expandLicenses(['GPL-2.0-or-later'], { expandScope: false })).toStrictEqual(['GPL-2.0', 'GPL-2.0-and-later', 'GPL-2.0-or-later'])
+        })
+    })
+})
+
+describe('of "WITH" as "w/"', () => {
+
+    it('"w/" is corrected when strictSyntax = false', () => {
+        const expression = 'GPL-3.0-only w/ Autoconf-exception-2.0'
+        expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        expect(parse(expression, { strictSyntax: false })).toMatchObject({
+            license: 'GPL-3.0-only',
+            exception: 'Autoconf-exception-2.0'
+        })
+    })
+
+    it('"W/" is corrected when strictSyntax = false', () => {
+        const expression = 'GPLv3+ W/ autoconf-exception-2.0'
+        expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        expect(parse(expression, { strictSyntax: false })).toMatchObject({
+            license: 'GPL-3.0-or-later',
+            exception: 'Autoconf-exception-2.0'
+        })
+    })
+
+    it('"w/" is corrected even when there is no whitespace before a valid exception', () => {
+        const expression = 'GPL-3.0-only w/autoconf-exception-2.0'
+        expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        expect(parse(expression, { strictSyntax: false })).toMatchObject({
+            license: 'GPL-3.0-only',
+            exception: 'Autoconf-exception-2.0'
+        })
+    })
+
+    it('"w/" is corrected even when there is no whitespace before an unknown exception', () => {
+        const expression = 'GPL-3.0-only w/not an exception'
+        expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        expect(parse(expression, { strictSyntax: false })).toMatchObject({
+            license: 'GPL-3.0-only',
+            exception: 'not an exception'
+        })
+    })
+
+    it("BSD 3-clause License w/nuclear disclaimer", () => {
+        const expression = "BSD 3-clause License w/nuclear disclaimer"
+        expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        expect(parse(expression, { strictSyntax: false })).toMatchObject({
+            license: 'BSD-3-Clause',
+            exception: 'nuclear disclaimer'
+        })
+    })
+
+    it('"w/" is not corrected even in liberal mode when there is no license identifier before it', () => {
+        expect(() => parse('w/whatever', { strictSyntax: true })).toThrowError()
+        expect(() => parse('w/whatever', { strictSyntax: false })).toThrowError()
+        expect(() => parse(' w/ whatever', { strictSyntax: true })).toThrowError()
+        expect(() => parse(' w/ whatever', { strictSyntax: false })).toThrowError()
+        expect(() => parse('XXXw/whatever', { strictSyntax: true })).toThrowError()
+        expect(() => parse('XXXw/whatever', { strictSyntax: false })).toThrowError()
+    })
+})
+
+describe('common misspellings', () => {
+
+    describe('of license exceptions', () => {
+
+        it('"autoconf exception 2.0" or "autoconf exception version 2" is corrected to Autoconf-exception-2.0', () => {
+            expect(parse('GPL-3.0-only WITH autoconf exception 2.0'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+            expect(parse('GPL-3.0-only WITH autoconf exception 2'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+            expect(parse('GPL-3.0-only WITH autoconf exception version 2'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+        })
+
+        it('with an extraneous "the" before the exception name/id', () => {
+            expect(parse('GPL-3.0-only WITH the autoconf exception 2'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+            expect(parse('GPL-3.0-only WITH the autoconf exception version 2.0'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+            expect(parse('GPL-3.0-only WITH the autoconf-exception-2.0'))
+                .toMatchObject({ exception: 'Autoconf-exception-2.0' })
+        })
+
+        it('fail parsing if strictSyntax = true', () => {
+            const expression = 'GPL-3.0-only WITH autoconf exception 2.0'
+            expect(() => parse(expression, { strictSyntax: false })).not.toThrowError()
+            expect(() => parse(expression, { strictSyntax: true })).toThrowError()
+        })
+
+        it('"Qwt License 1.0" is corrected to "Qwt-exception-1.0"', () => {
+            expect(parse('LGPL-2.1 WITH Qwt License 1.0')).toMatchObject({ exception: 'Qwt-exception-1.0' })
+            expect(parse('LGPL-2.1 WITH Qwt License Version 1.0')).toMatchObject({ exception: 'Qwt-exception-1.0' })
+        })
+
+        it('"UBoot exception 2.0" is corrected to "u-boot-exception-2.0"', () => {
+            expect(parse('GPL-2.0+ WITH UBoot exception 2.0')).toMatchObject({ exception: 'u-boot-exception-2.0' })
+            expect(parse('GPL-2.0+ WITH UBoot exception 2')).toMatchObject({ exception: 'u-boot-exception-2.0' })
+        })
+
+        it('"GNU Classpath Exception 2.0" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH GNU Classpath Exception 2.0')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+
+        it('"GNU Classpath Exception" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH GNU Classpath Exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+
+        it('"GNU Classpath Exception 2.0" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH GNU Classpath Exception 2.0')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+
+        it('"classpath exception" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH classpath exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+
+        it('"the classpath exception" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH the classpath exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+
+        it('"CPE" is corrected to "Classpath-exception-2.0"', () => {
+            expect(parse('GPL-2.0-only WITH CPE')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
+        })
+    })
+})

--- a/tests/corrections.licenses.test.ts
+++ b/tests/corrections.licenses.test.ts
@@ -389,22 +389,9 @@ describe('Expressions with slight errors', () => {
         })
     })
 
-    describe('whitespace instead of dashes', () => {
-        it('Apache-2.0 WITH LLVM Exception', () => {
-            expect(parse('Apache 2.0 WITH LLVM exception')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
-            expect(parse('apache 2.0 WITH LLVM Exception')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
-            expect(parse('apache 2.0 WITH llvm exception')).toStrictEqual({ license: 'Apache-2.0', exception: 'LLVM-exception' })
-        })
-
-        it('GPL-2.0-only WITH Classpath Exception 2.0', () => {
-            expect(parse('GPL-2.0-only WITH Classpath Exception 2.0')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-        })
-    })
-
-    describe('misspelling that has no fix', () => {
-        it('renders the exception in its original form', () => {
-            expect(parse('MIT WITH No Such Exception')).toStrictEqual({ license: 'MIT', exception: 'No Such Exception' })
-        })
+    it('misspelled license identifier that has no fix is left as-is', () => {
+        expect(parse('No Such License')).toStrictEqual({ license: 'No Such License' })
+        expect(parse('No Such License WITH Classpath-exception-2.0')).toStrictEqual({ license: 'No Such License', exception: 'Classpath-exception-2.0' })
     })
 
     describe('keyword in the license name', () => {
@@ -549,7 +536,7 @@ describe('Expressions with slight errors', () => {
         describe('of "AND" as "plus"', () => {
             describe('"plus" is not corrected when strictSyntax = true', () => {
                 const examples = [
-                    'Apache-2.0 plus MIT', 'CDDL-1.1 plus GPL-2.0-with-classpath-exception', 'CDDL-1.1 plus GPL-2.0-with-classpath-exception'
+                    'Apache-2.0 plus MIT', 'CDDL-1.1 plus GPL-2.0-with-classpath-exception', 'CDDL-1.1 plus GPL-2.0 WITH Classpath-exception-2.0'
                 ]
                 examples.forEach(expression => {
                     it(JSON.stringify(expression), () => expect(() => parse(expression, { strictSyntax: true })).toThrowError())
@@ -581,124 +568,6 @@ describe('Expressions with slight errors', () => {
                         right: { license: 'GPL-2.0-with-classpath-exception' },
                     })
                 })
-            })
-        })
-
-        describe('of "WITH" as "w/"', () => {
-
-            it('"w/" is corrected when strictSyntax = false', () => {
-                const expression = 'GPL-3.0-only w/ Autoconf-exception-2.0'
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-                expect(parse(expression, { strictSyntax: false })).toMatchObject({
-                    license: 'GPL-3.0-only',
-                    exception: 'Autoconf-exception-2.0'
-                })
-            })
-
-            it('"W/" is corrected when strictSyntax = false', () => {
-                const expression = 'GPLv3+ W/ autoconf-exception-2.0'
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-                expect(parse(expression, { strictSyntax: false })).toMatchObject({
-                    license: 'GPL-3.0-or-later',
-                    exception: 'Autoconf-exception-2.0'
-                })
-            })
-
-            it('"w/" is corrected even when there is no whitespace before a valid exception', () => {
-                const expression = 'GPL-3.0-only w/autoconf-exception-2.0'
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-                expect(parse(expression, { strictSyntax: false })).toMatchObject({
-                    license: 'GPL-3.0-only',
-                    exception: 'Autoconf-exception-2.0'
-                })
-            })
-
-            it('"w/" is corrected even when there is no whitespace before an unknown exception', () => {
-                const expression = 'GPL-3.0-only w/not an exception'
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-                expect(parse(expression, { strictSyntax: false })).toMatchObject({
-                    license: 'GPL-3.0-only',
-                    exception: 'not an exception'
-                })
-            })
-
-            it("BSD 3-clause License w/nuclear disclaimer", () => {
-                const expression = "BSD 3-clause License w/nuclear disclaimer"
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-                expect(parse(expression, { strictSyntax: false })).toMatchObject({
-                    license: 'BSD-3-Clause',
-                    exception: 'nuclear disclaimer'
-                })
-            })
-
-            it('"w/" is not corrected even in liberal mode when there is no license identifier before it', () => {
-                expect(() => parse('w/whatever', { strictSyntax: true })).toThrowError()
-                expect(() => parse('w/whatever', { strictSyntax: false })).toThrowError()
-                expect(() => parse(' w/ whatever', { strictSyntax: true })).toThrowError()
-                expect(() => parse(' w/ whatever', { strictSyntax: false })).toThrowError()
-                expect(() => parse('XXXw/whatever', { strictSyntax: true })).toThrowError()
-                expect(() => parse('XXXw/whatever', { strictSyntax: false })).toThrowError()
-            })
-        })
-
-        describe('of license exceptions', () => {
-
-            it('"autoconf exception 2.0" or "autoconf exception version 2" is corrected to Autoconf-exception-2.0', () => {
-                expect(parse('GPL-3.0-only WITH autoconf exception 2.0'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-                expect(parse('GPL-3.0-only WITH autoconf exception 2'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-                expect(parse('GPL-3.0-only WITH autoconf exception version 2'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-            })
-
-            it('with an extraneous "the" before the exception name/id', () => {
-                expect(parse('GPL-3.0-only WITH the autoconf exception 2'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-                expect(parse('GPL-3.0-only WITH the autoconf exception version 2.0'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-                expect(parse('GPL-3.0-only WITH the autoconf-exception-2.0'))
-                    .toMatchObject({ exception: 'Autoconf-exception-2.0' })
-            })
-
-            it('fail parsing if strictSyntax = true', () => {
-                const expression = 'GPL-3.0-only WITH autoconf exception 2.0'
-                expect(() => parse(expression, { strictSyntax: false })).not.toThrowError()
-                expect(() => parse(expression, { strictSyntax: true })).toThrowError()
-            })
-
-            it('"Qwt License 1.0" is corrected to "Qwt-exception-1.0"', () => {
-                expect(parse('LGPL-2.1 WITH Qwt License 1.0')).toMatchObject({ exception: 'Qwt-exception-1.0' })
-                expect(parse('LGPL-2.1 WITH Qwt License Version 1.0')).toMatchObject({ exception: 'Qwt-exception-1.0' })
-            })
-
-            it('"UBoot exception 2.0" is corrected to "u-boot-exception-2.0"', () => {
-                expect(parse('GPL-2.0+ WITH UBoot exception 2.0')).toMatchObject({ exception: 'u-boot-exception-2.0' })
-                expect(parse('GPL-2.0+ WITH UBoot exception 2')).toMatchObject({ exception: 'u-boot-exception-2.0' })
-            })
-
-            it('"GNU Classpath Exception 2.0" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH GNU Classpath Exception 2.0')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-            })
-
-            it('"GNU Classpath Exception" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH GNU Classpath Exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-            })
-
-            it('"GNU Classpath Exception 2.0" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH GNU Classpath Exception 2.0')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-            })
-
-            it('"classpath exception" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH classpath exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-            })
-
-            it('"the classpath exception" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH the classpath exception')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
-            })
-
-            it('"CPE" is corrected to "Classpath-exception-2.0"', () => {
-                expect(parse('GPL-2.0-only WITH CPE')).toStrictEqual({ license: 'GPL-2.0-only', exception: 'Classpath-exception-2.0' })
             })
         })
 

--- a/tests/corrections.test.ts
+++ b/tests/corrections.test.ts
@@ -546,6 +546,44 @@ describe('Expressions with slight errors', () => {
             })
         })
 
+        describe('of "AND" as "plus"', () => {
+            describe('"plus" is not corrected when strictSyntax = true', () => {
+                const examples = [
+                    'Apache-2.0 plus MIT', 'CDDL-1.1 plus GPL-2.0-with-classpath-exception', 'CDDL-1.1 plus GPL-2.0-with-classpath-exception'
+                ]
+                examples.forEach(expression => {
+                    it(JSON.stringify(expression), () => expect(() => parse(expression, { strictSyntax: true })).toThrowError())
+                })
+            })
+
+            describe('"plus" is corrected when strictSyntax = false', () => {
+
+                it('Apache-2.0 plus MIT', () => {
+                    expect(parse('Apache-2.0 plus MIT', { strictSyntax: false })).toMatchObject({
+                        conjunction: 'and',
+                        left: { license: 'Apache-2.0' },
+                        right: { license: 'MIT' },
+                    })
+                })
+
+                it('CDDL-1.1 plus GPL-2.0 WITH Classpath-exception-2.0', () => {
+                    expect(parse('CDDL-1.1 plus GPL-2.0 WITH Classpath-exception-2.0', { strictSyntax: false })).toMatchObject({
+                        conjunction: 'and',
+                        left: { license: 'CDDL-1.1' },
+                        right: { license: 'GPL-2.0', exception: 'Classpath-exception-2.0' },
+                    })
+                })
+
+                it('CDDL-1.1 plus GPL-2.0-with-classpath-exception', () => {
+                    expect(parse('CDDL-1.1 plus GPL-2.0-with-classpath-exception', { strictSyntax: false })).toMatchObject({
+                        conjunction: 'and',
+                        left: { license: 'CDDL-1.1' },
+                        right: { license: 'GPL-2.0-with-classpath-exception' },
+                    })
+                })
+            })
+        })
+
         describe('of "WITH" as "w/"', () => {
 
             it('"w/" is corrected when strictSyntax = false', () => {

--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -1,0 +1,1 @@
+import "jest-extended";


### PR DESCRIPTION
SPDX data recently gained a new license exception, `Bison-exception-1.24`, which exposed a prior assumption/simplification as a bug:

Inputs such as "GPL-3.0-with-bison-exception" that were previously correctly coerced into "GPL-3.0 WITH Bison-exception-2.2", now yielded "GPL-3.0 WITH Bison-exception-1.24" whereas the more appropriate outcome would be to assume the newer version of said license exception in presence of ambiguity.

Simply picking the newest license instead of the first from an alphabetically sorted list would not be sufficient either, however, as it turns out that there are cases like the Autoconf exception, which comes in two versions:

- `Autoconf-exception-2.0` that should be used with the GPLv2 family
- `Autoconf-exception-3.0` that should be used with the GPLv3 family

This PR implements proper association-matching based on a list of "related licenses" associated with a license exception, replacing the previous, effectively random selection in situations where an ambiguous license exception was matched by name/prefix to multiple SPDX identifiers.