### PR TITLE
Adopt `licenses-from-spdx` for getting the license data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
         "@types/tmp": "^0.2.3",
         "jest": "^29.4.0",
         "jest-extended": "^4.0.2",
+        "licenses-from-spdx": "^1.1.2",
         "tmp": "^0.2.1",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.4.0",
         "tspeg": "^3.2.0",
-        "tsx": "^4.19.4",
         "typescript": "^5.3.3"
       }
     },
@@ -652,431 +652,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2638,47 +2213,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -2754,6 +2288,25 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.3.tgz",
+      "integrity": "sha512-OdCYfRqfpuLUFonTNjvd30rCBZUneHpSQkCqfaeWQ9qrKcl6XlWeDBNVwGb+INAIxRshuN2jF+BE0L6gbBO2mw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2885,19 +2438,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4891,6 +4431,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/licenses-from-spdx": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/licenses-from-spdx/-/licenses-from-spdx-1.1.2.tgz",
+      "integrity": "sha512-VB4uMAxqcYkZKK7yG1g9cgWYxtJ8qwasP+5gbEFwlQ/fIC/oUv8NCqHDBOsXsMgck43rZnvkob5qA1HPDy1lDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.0.6"
+      },
+      "bin": {
+        "licenses-from-spdx": "build/cli/cli.js"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5332,16 +4885,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -5551,6 +5094,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -5733,26 +5289,6 @@
       },
       "bin": {
         "tspeg": "tsbuild/cli.js"
-      }
-    },
-    "node_modules/tsx": {
-      "version": "4.19.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
-      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.25.0",
-        "get-tsconfig": "^4.7.5"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-detect": {
@@ -6447,181 +5983,6 @@
           }
         }
       }
-    },
-    "@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-      "dev": true,
-      "optional": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -7830,39 +7191,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-      "dev": true,
-      "requires": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
-      }
-    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -7916,6 +7244,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.3.tgz",
+      "integrity": "sha512-OdCYfRqfpuLUFonTNjvd30rCBZUneHpSQkCqfaeWQ9qrKcl6XlWeDBNVwGb+INAIxRshuN2jF+BE0L6gbBO2mw==",
+      "dev": true,
+      "requires": {
+        "strnum": "^2.1.0"
+      }
     },
     "fb-watchman": {
       "version": "2.0.2",
@@ -8016,15 +7353,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
-    },
-    "get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
-      "requires": {
-        "resolve-pkg-maps": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.2.3",
@@ -9490,6 +8818,15 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
+    "licenses-from-spdx": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/licenses-from-spdx/-/licenses-from-spdx-1.1.2.tgz",
+      "integrity": "sha512-VB4uMAxqcYkZKK7yG1g9cgWYxtJ8qwasP+5gbEFwlQ/fIC/oUv8NCqHDBOsXsMgck43rZnvkob5qA1HPDy1lDA==",
+      "dev": true,
+      "requires": {
+        "fast-xml-parser": "^5.0.6"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9814,12 +9151,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true
-    },
     "resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -9986,6 +9317,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true
+    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -10084,17 +9421,6 @@
       "dev": true,
       "requires": {
         "yargs": "^17.1.1"
-      }
-    },
-    "tsx": {
-      "version": "4.19.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
-      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
-      "dev": true,
-      "requires": {
-        "esbuild": "~0.25.0",
-        "fsevents": "~2.3.3",
-        "get-tsconfig": "^4.7.5"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "@types/tmp": "^0.2.3",
     "jest": "^29.4.0",
     "jest-extended": "^4.0.2",
+    "licenses-from-spdx": "^1.1.2",
     "tmp": "^0.2.1",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.4.0",
     "tspeg": "^3.2.0",
-    "tsx": "^4.19.4",
     "typescript": "^5.3.3"
   },
   "dependencies": {

--- a/scripts/codegen-license-update.ts
+++ b/scripts/codegen-license-update.ts
@@ -1,280 +1,95 @@
-import https from 'https'
-import fs from 'fs'
-import os from 'os'
-import path from 'path'
-import crypto from 'crypto'
-import { pipeline } from 'stream'
+import fs from "fs";
+import { generateLicenseData, Licenses, License, Exceptions, Exception } from "licenses-from-spdx";
 
+import { extractLicenseIdentifiersReferredTo } from "./license-data-enrichment";
+import { tmpdir } from "os";
+import { join } from "path";
 
-const LICENSE_FILE_URL = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json"
-const EXCEPTIONS_FILE_URL = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json"
-const EXCEPTION_DETAILS_FILE_BASEURL = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions/"
-const DETAILS_DOWNLOAD_BATCH_SIZE = 10
+type InternalLicense = {
+    name: string;
+    licenseId: string;
+    deprecated: boolean;
+};
 
+type InternalException = {
+    name: string;
+    licenseExceptionId: string;
+    relatedLicenses: string[];
+    deprecated: boolean;
+};
 
-const hash = (str) => {
-    let shasum = crypto.createHash('sha1')
-    shasum.update(str)
-    return shasum.digest('hex')
-}
-
-const downloadJSON = async (url: string): Promise<object> => {
-    const rawJson = await new Promise<string>((resolve, _reject) => {
-        const tmpFilePath = path.join(os.tmpdir(), hash(url))
-        https.get(url, { agent: false }, (response) => {
-            const errorHandler = (err) => {
-                if (err) {
-                    console.warn(`Could not download JSON from ${url} - ${err}`)
-                    resolve('{}')
-                } else {
-                    resolve(fs.readFileSync(tmpFilePath).toString())
-                }
-            }
-            if (response.statusCode === 200) {
-                pipeline(response, fs.createWriteStream(tmpFilePath), errorHandler)
-            } else {
-                errorHandler(`HTTP ${response.statusCode} ${response.statusMessage ? response.statusMessage : ''}`.trimEnd())
-            }
-        })
-    })
-    try {
-        return JSON.parse(rawJson)
-    } catch (err) {
-        console.error(`Error parsing JSON from ${url}: ${err}\n\nRaw content:\n${rawJson}`)
+async function updateLicenseFileAt(destinationFilePath: string, licenses: Licenses) {
+    const licenseDetailsObjectMapper = (license: License): InternalLicense => {
         return {
-            error: `Error parsing JSON from ${url}: ${err}`,
-            details: `Raw content received:\n${rawJson}`
-        }
-    }
-}
-
-function sliceIntoChunks<T>(arr: Array<T>, chunkSize: number): Array<Array<T>> {
-    const res: Array<Array<T>> = []
-    for (let i = 0; i < arr.length; i += chunkSize) {
-        const chunk = arr.slice(i, i + chunkSize)
-        res.push(chunk)
-    }
-    return res
-}
-
-const downloadManyJSONFiles = async (arrayOfURLs: string[]): Promise<object[]> => {
-    const batches = sliceIntoChunks(arrayOfURLs, DETAILS_DOWNLOAD_BATCH_SIZE)
-    const results: object[] = []
-    for (let b = 0; b < batches.length; b++) {
-        const batch = batches[b]
-        console.log(`Downloading batch ${b+1} (${batch.length} entries)`)
-        const batchResults = await Promise.all(batch.map(downloadJSON))
-        batchResults.forEach(result => results.push(result))
-    }
-    return results
-}
-
-const readLicenseListVersionFromJsonObject = (jsonObj) => {
-    return jsonObj.licenseListVersion
-}
-
-const readLicensesFromFile = (file_path) => {
-    if (fs.existsSync(file_path)) {
-        const jsonObj = JSON.parse(fs.readFileSync(file_path).toString())
-        return jsonObj.licenses.filter(x => !!x)
-    }
-    console.warn(`File ${file_path} does not exist - can't read licenses from it`)
-    return []
-}
-
-const readLicenseListVersionFromFile = (file_path) => {
-    if (fs.existsSync(file_path)) {
-        const jsonObj = JSON.parse(fs.readFileSync(file_path).toString())
-        return readLicenseListVersionFromJsonObject(jsonObj)
-    }
-    return ''
-}
-
-const updateFileFromURL = async (destinationFilePath, sourceUrl, entryListKey, detailsUrlMapper, detailsObjectMapper) => {
-    const json = await downloadJSON(sourceUrl)
-    const latestVersion = readLicenseListVersionFromJsonObject(json)
-    const localVersion = readLicenseListVersionFromFile(destinationFilePath)
-    if (!!latestVersion && latestVersion === localVersion) {
-        console.log(`${destinationFilePath} already has version ${latestVersion} from ${sourceUrl} --> skip update`)
-    } else {
-        console.log(`Update available (from ${localVersion} to ${latestVersion}) --> updating ${entryListKey}`)
-        const licensesInMainDocument = json[entryListKey]
-        const urls = licensesInMainDocument.map(detailsUrlMapper).filter(url => !!url)
-        const details = await downloadManyJSONFiles(urls)
-        json[entryListKey] = details.filter(x => !!x && !(x as any).error).map(detailsObjectMapper).filter(x => !!x && (!!(x as any).licenseExceptionId || !!(x as any).licenseId))
-        fs.writeFileSync(destinationFilePath, JSON.stringify(json, null, 2))
-        console.log(`Updated ${destinationFilePath} with version ${latestVersion} from ${sourceUrl}`)
-        const entriesWithMissingDetails = licensesInMainDocument.filter(x => !details.find(d => (d as any).licenseId === x.licenseId))
-        if (entriesWithMissingDetails.length > 0) {
-            console.warn(`Some entries (${entriesWithMissingDetails.length}) were missing from the details files. Got ${json[entryListKey].length} out of ${licensesInMainDocument.length} but failed on the following entries:\n${JSON.stringify(entriesWithMissingDetails, null, 2)}`)
-        }
-    }
-}
-
-const updateLicenseFileAt = async (destinationFilePath) => {
-    const licenseDetailsUrlMapper = (license) => license.detailsUrl
-    const licenseDetailsObjectMapper = (license) => {
-        if (license && license.licenseId) {
-            return {
-                name: license.name,
-                licenseId: license.licenseId,
-                isDeprecatedLicenseId: !!license.isDeprecatedLicenseId,
-                isOsiApproved: !!license.isOsiApproved,
-                isFsfLibre: !!license.isFsfLibre,
-                seeAlso: license.seeAlso
-            }
-        }
-        return undefined
-    }
+            name: license.name,
+            licenseId: license.licenseId,
+            deprecated: license.isDeprecated || false,
+        };
+    };
     try {
-        await updateFileFromURL(destinationFilePath, LICENSE_FILE_URL, 'licenses', licenseDetailsUrlMapper, licenseDetailsObjectMapper)
+        const internalLicenses = licenses.licenses.map(licenseDetailsObjectMapper);
+        fs.writeFileSync(destinationFilePath, JSON.stringify(internalLicenses, null, 2));
     } catch (err) {
-        console.error(`Updating ${destinationFilePath} failed: ${err}`, err)
+        console.error(`Updating ${destinationFilePath} failed: ${err}`, err);
     }
 }
 
-function unique<T>(items: T[]): T[] {
-    return [...new Set(items)]
-}
-
-const expandListOfKnownLicenses = (ids) => {
-    ids.filter(id => !!id && id.endsWith('+')).forEach(id => {
-        ids.push(id.replace(/\+$/, '-or-later'))
-        ids.push(id.replace(/\+$/, '-and-later'))
-    })
-    return ids
-}
-
-const expandListOfMentionedLicenses = (words) => {
-    words.filter(w => w === 'gpl').forEach(w => {
-        words.push('gpl-2.0')
-        words.push('gpl-3.0')
-    })
-    words.filter(w => w === 'lgpl').forEach(w => {
-        words.push('lgpl-2.0')
-        words.push('lgpl-2.1')
-        words.push('lgpl-3.0')
-    })
-    words.filter(w => w.match(/^[al]?gpl.*\-and\-later$/)).forEach(w => {
-        words.push(w.replace(/^([al]?gpl.*)\-and\-later$/, '$1-or-later'))
-    })
-    return words
-}
-
-const sanitizeSpecialCharacters = (text: string): string => {
-    return text.replace(/[^a-zA-Z0-9\.\-\+]/g, ' ').replace(/\s+/g, ' ')
-}
-
-const findLicensesMentionedInLicenseComments = (licenses, entry, explicitGplVersionsOnly = true) => {
-    const knownLicenseIds = expandListOfKnownLicenses(licenses.map(x => x.licenseId)).filter(x => !!x)
-    const lowercaseLicenseIds = knownLicenseIds.map(x => x.toLowerCase())
-    const textFromLicenseComments = sanitizeSpecialCharacters(entry.licenseComments || '').replace(/[\.,](\s|$)/g, ' ').replace(/(GPL)\s+(\d\.\d)/g, '$1-$2')
-    const uniqueWords = unique(textFromLicenseComments.trim().split(/\s+/).map(w => w.toLowerCase()))
-    const expandedWords = explicitGplVersionsOnly ? uniqueWords : expandListOfMentionedLicenses(uniqueWords)
-    const licensesMentioned = expandedWords.filter(w => lowercaseLicenseIds.includes(w)).map(id => id.replace(/\+$/, '-or-later'))
-    return licensesMentioned.map(lc => knownLicenseIds.find(x => x.toLowerCase() === lc))
-}
-
-const findLicensesMentionedInExceptionName = (licenses, entry, explicitGplVersionsOnly = true) => {
-    const knownLicenseIds = expandListOfKnownLicenses(licenses.map(x => x.licenseId)).filter(x => !!x)
-    const lowercaseLicenseIds = knownLicenseIds.map(x => x.toLowerCase())
-    const text = sanitizeSpecialCharacters(entry.name || '').replace(/(GPL)\s+(\d\.\d)/g, '$1-$2').split(/\s+/).filter(w => w.startsWith('LGPL') || w.startsWith('GPL') || w.startsWith('AGPL')).join(' ').trim()
-    const uniqueWords = unique(text.split(/\s+/).map(w => w.toLowerCase()))
-    const expandedWords = explicitGplVersionsOnly ? uniqueWords : expandListOfMentionedLicenses(uniqueWords.map(w => w.replace(/\.$/, '')))
-    const licensesMentioned = expandedWords.filter(w => lowercaseLicenseIds.includes(w)).map(id => id.replace(/\+$/, '-or-later'))
-    return licensesMentioned.map(lc => knownLicenseIds.find(x => x.toLowerCase() === lc))
-}
-
-const extractLicenseIdentifiersReferredTo = (licenses, entry) => {
-    const methods = [
-        () => findLicensesMentionedInLicenseComments(licenses, entry, true),
-        () => findLicensesMentionedInExceptionName(licenses, entry, true),
-        () => findLicensesMentionedInLicenseComments(licenses, entry, false),
-        () => findLicensesMentionedInExceptionName(licenses, entry, false)
-    ]
-    let mentions = []
-    methods.forEach(method => {
-        if (mentions.length === 0) {
-            mentions = method()
-        }
-    })
-    // for (let i=0; mentions.length === 0 && i < methods.length; i++) {
-    //     mentions.push(methods[i]())
-    // }
-    return mentions.flat()
-}
-
-const updateExceptionsFileAt = async (exceptionsFilePath, licensesFilePath) => {
-    const exceptionDetailsUrlMapper = (entry) => {
-        if (entry.detailsUrl?.startsWith('http') && entry.detailsUrl?.endsWith('.json')) {
-            return entry.detailsUrl
-        }
-        if (entry.licenseExceptionId) {
-            return EXCEPTION_DETAILS_FILE_BASEURL + entry.licenseExceptionId + '.json'
-        }
-        console.warn(`Unexpected entry structure: ${JSON.stringify(entry, null, 2)}`)
-        return undefined
-    }
-    const exceptionDetailsObjectMapper = (licenses) => {
-        return (entry) => {
-            let licensesMentionedInComments = extractLicenseIdentifiersReferredTo(licenses, entry)
-            return {
-                licenseExceptionId: entry.licenseExceptionId,
-                isDeprecatedLicenseId: entry.isDeprecatedLicenseId,
-                // licenseExceptionText: entry.licenseExceptionText,
-                name: entry.name,
-                seeAlso: entry.seeAlso,
-                licenseComments: entry.licenseComments,
-                relatedLicenses: licensesMentionedInComments,
-            }
-        }
-    }
+async function updateExceptionsFileAt(destinationFilePath: string, exceptions: Exceptions, licenses: Licenses) {
+    const exceptionDetailsObjectMapper = (entry: Exception): InternalException => {
+        return {
+            name: entry.name,
+            licenseExceptionId: entry.licenseExceptionId,
+            relatedLicenses: extractLicenseIdentifiersReferredTo(licenses.licenses, entry),
+            deprecated: entry.isDeprecated || false,
+        };
+    };
     try {
-        const licenses = readLicensesFromFile(licensesFilePath)
-        await updateFileFromURL(exceptionsFilePath, EXCEPTIONS_FILE_URL, 'exceptions', exceptionDetailsUrlMapper, exceptionDetailsObjectMapper(licenses))
+        const internalExceptions = exceptions.exceptions.map(exceptionDetailsObjectMapper);
+        fs.writeFileSync(destinationFilePath, JSON.stringify(internalExceptions, null, 2));
     } catch (err) {
-        console.error(`Updating ${exceptionsFilePath} failed: ${err}`, err)
+        console.error(`Updating ${destinationFilePath} failed: ${err}`, err);
     }
 }
 
-const fileIsOlderThan = (oldestAcceptableTimestamp, filePath) => {
-    return fs.statSync(filePath).mtime < oldestAcceptableTimestamp
-}
+const counter = (() => {
+    let counter = 0;
+    return (): number => {
+        return counter++;
+    };
+})();
 
-async function updateLicenseFileIfOlderThan(oldestAcceptableTimestamp: Date, licenseFilePath: string) {
-    if (!fs.existsSync(licenseFilePath) || fileIsOlderThan(oldestAcceptableTimestamp, licenseFilePath)) {
-        return await updateLicenseFileAt(licenseFilePath)
-    } else {
-        console.log(`Not updating ${licenseFilePath} (it's recent enough)`)
+function tmpfile(): string {
+    const maxAttempts = 1000000;
+    for (let i = 0; i < maxAttempts; i++) {
+        const file = join(tmpdir(), `${Date.now()}${counter()}`);
+        if (!fs.existsSync(file)) {
+            return file;
+        }
     }
-}
-
-async function updateExceptionsFileIfOlderThan(oldestAcceptableTimestamp: Date, exceptionsFilePath: string, licenseFilePath: string) {
-    if (!fs.existsSync(exceptionsFilePath) || fileIsOlderThan(oldestAcceptableTimestamp, exceptionsFilePath)) {
-        return await updateExceptionsFileAt(exceptionsFilePath, licenseFilePath)
-    } else {
-        console.log(`Not updating ${exceptionsFilePath} (it's recent enough)`)
-    }
-}
-
-function dateHoursBeforeNow(hours: number): Date {
-    const d = new Date()
-    const nowInMillis = d.getTime()
-    return new Date(nowInMillis - hours * 60 * 60 * 1000)
+    throw new Error(`Failed to create a unique temporary file after ${maxAttempts} attempts`);
 }
 
 async function main(licenseFilePath: string, exceptionsFilePath: string) {
-    const oldestAcceptableTimestamp = dateHoursBeforeNow(24)
-    await updateLicenseFileIfOlderThan(oldestAcceptableTimestamp, licenseFilePath)
-    await updateExceptionsFileIfOlderThan(oldestAcceptableTimestamp, exceptionsFilePath, licenseFilePath)
-    console.log('Done.')
+    // use licenses-from-spdx to generate the license and exceptions data in temporary files
+    const options = {
+        excludeHtml: true,
+        excludeTemplates: true,
+        excludeText: true,
+    };
+    const { licenses, exceptions } = await generateLicenseData(tmpfile(), tmpfile(), options);
+
+    // Update exceptions file with related licenses
+    await updateExceptionsFileAt(exceptionsFilePath, exceptions, licenses);
+
+    // Trim down the license file now that we've updated the exceptions file
+    await updateLicenseFileAt(licenseFilePath, licenses);
 }
 
 (async () => {
     try {
-        const [licenseFilePath, exceptionsFilePath] = process.argv.slice(2)
-        await main(licenseFilePath, exceptionsFilePath)
+        const [licenseFilePath, exceptionsFilePath] = process.argv.slice(2);
+        await main(licenseFilePath, exceptionsFilePath);
     } catch (e) {
-        console.error(e)
+        console.error(e);
     }
-})()
+})();

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -14,7 +14,5 @@ done
 # Update `src/codegen/licenses.json` and `src/codegen/exceptions.json` from SPDX's
 # Github repository if it's older than a day:
 #
-
-license_file="src/codegen/licenses.json"
-exceptions_file="src/codegen/exceptions.json"
-npx tsx scripts/codegen-license-update.ts "$license_file" "$exceptions_file"
+#npx licenses-from-spdx -l src/codegen/licenses.json -e src/codegen/exceptions.json
+npx tsx scripts/codegen-license-update.ts src/codegen/licenses.json src/codegen/exceptions.json

--- a/scripts/license-data-enrichment.ts
+++ b/scripts/license-data-enrichment.ts
@@ -1,0 +1,105 @@
+import { Exception, License } from "licenses-from-spdx";
+
+function unique<T>(items: T[]): T[] {
+    return [...new Set(items)];
+}
+
+function expandListOfKnownLicenses(ids: string[]): string[] {
+    ids.filter((id) => !!id && id.endsWith("+")).forEach((id) => {
+        ids.push(id.replace(/\+$/, "-or-later"));
+        ids.push(id.replace(/\+$/, "-and-later"));
+    });
+    return ids;
+}
+
+function expandListOfMentionedLicenses(words: string[]): string[] {
+    words
+        .filter((w) => w === "gpl")
+        .forEach((_) => {
+            words.push("gpl-2.0");
+            words.push("gpl-3.0");
+        });
+    words
+        .filter((w) => w === "lgpl")
+        .forEach((_) => {
+            words.push("lgpl-2.0");
+            words.push("lgpl-2.1");
+            words.push("lgpl-3.0");
+        });
+    words
+        .filter((w) => w.match(/^[al]?gpl.*\-and\-later$/))
+        .forEach((w) => {
+            words.push(w.replace(/^([al]?gpl.*)\-and\-later$/, "$1-or-later"));
+        });
+    return words;
+}
+
+function sanitizeSpecialCharacters(text: string): string {
+    return text.replace(/[^a-zA-Z0-9\.\-\+]/g, " ").replace(/\s+/g, " ");
+}
+
+function isString(x: any): x is string {
+    return typeof x === "string";
+}
+
+function isNonEmptyString(x: any): x is string {
+    return isString(x) && x.trim().length > 0;
+}
+
+function findLicensesMentionedInLicenseComments(
+    licenses: License[],
+    entry: Exception,
+    explicitGplVersionsOnly = true
+): string[] {
+    const knownLicenseIds = expandListOfKnownLicenses(licenses.map((x) => x.licenseId)).filter((x) => !!x);
+    const lowercaseLicenseIds = knownLicenseIds.map((x) => x.toLowerCase());
+    const textFromLicenseComments = sanitizeSpecialCharacters(entry.licenseComments || "")
+        .replace(/[\.,](\s|$)/g, " ")
+        .replace(/(GPL)\s+(\d\.\d)/g, "$1-$2");
+    const uniqueWords = unique(
+        textFromLicenseComments
+            .trim()
+            .split(/\s+/)
+            .map((w) => w.toLowerCase())
+    );
+    const expandedWords = explicitGplVersionsOnly ? uniqueWords : expandListOfMentionedLicenses(uniqueWords);
+    const licensesMentioned = expandedWords
+        .filter((w) => lowercaseLicenseIds.includes(w))
+        .map((id) => id.replace(/\+$/, "-or-later"));
+    return licensesMentioned.map((lc) => knownLicenseIds.find((x) => x.toLowerCase() === lc)).filter(isNonEmptyString);
+}
+
+function findLicensesMentionedInExceptionName(licenses, entry, explicitGplVersionsOnly = true): string[] {
+    const knownLicenseIds = expandListOfKnownLicenses(licenses.map((x) => x.licenseId)).filter((x) => !!x);
+    const lowercaseLicenseIds = knownLicenseIds.map((x) => x.toLowerCase());
+    const text = sanitizeSpecialCharacters(entry.name || "")
+        .replace(/(GPL)\s+(\d\.\d)/g, "$1-$2")
+        .split(/\s+/)
+        .filter((w) => w.startsWith("LGPL") || w.startsWith("GPL") || w.startsWith("AGPL"))
+        .join(" ")
+        .trim();
+    const uniqueWords = unique(text.split(/\s+/).map((w) => w.toLowerCase()));
+    const expandedWords = explicitGplVersionsOnly
+        ? uniqueWords
+        : expandListOfMentionedLicenses(uniqueWords.map((w) => w.replace(/\.$/, "")));
+    const licensesMentioned = expandedWords
+        .filter((w) => lowercaseLicenseIds.includes(w))
+        .map((id) => id.replace(/\+$/, "-or-later"));
+    return licensesMentioned.map((lc) => knownLicenseIds.find((x) => x.toLowerCase() === lc)).filter(isNonEmptyString);
+}
+
+export function extractLicenseIdentifiersReferredTo(licenses: License[], entry: Exception): string[] {
+    const methods = [
+        () => findLicensesMentionedInLicenseComments(licenses, entry, true),
+        () => findLicensesMentionedInExceptionName(licenses, entry, true),
+        () => findLicensesMentionedInLicenseComments(licenses, entry, false),
+        () => findLicensesMentionedInExceptionName(licenses, entry, false),
+    ];
+    let mentions: string[] = [];
+    methods.forEach((method) => {
+        if (mentions.length === 0) {
+            mentions = method();
+        }
+    });
+    return mentions.flat();
+}

--- a/src/codegen/exceptions.json
+++ b/src/codegen/exceptions.json
@@ -1,928 +1,610 @@
-{
-  "licenseListVersion": "21b8e53",
-  "exceptions": [
-    {
-      "licenseExceptionId": "389-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "389 Directory Server Exception",
-      "seeAlso": [
-        "http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text",
-        "https://web.archive.org/web/20080828121337/http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text"
-      ],
-      "licenseComments": "Specified to be associated with GPL-2.0-only",
-      "relatedLicenses": [
-        "GPL-2.0-only"
-      ]
-    },
-    {
-      "licenseExceptionId": "Asterisk-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Asterisk exception",
-      "seeAlso": [
-        "https://github.com/asterisk/libpri/blob/7f91151e6bd10957c746c031c1f4a030e8146e9a/pri.c#L22",
-        "https://github.com/asterisk/libss7/blob/03e81bcd0d28ff25d4c77c78351ddadc82ff5c3f/ss7.c#L24"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Asterisk-linking-protocols-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Asterisk linking protocols exception",
-      "seeAlso": [
-        "https://github.com/asterisk/asterisk/blob/115d7c01e32ccf4566a99e9d74e2b88830985a0b/LICENSE#L27"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Autoconf-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Autoconf exception 2.0",
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html",
-        "http://ftp.gnu.org/gnu/autoconf/autoconf-2.59.tar.gz"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Autoconf-exception-3.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Autoconf exception 3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ],
-      "licenseComments": "Typically used with GPL-3.0-only or GPL-3.0-and-later",
-      "relatedLicenses": [
-        "GPL-3.0-only",
-        "GPL-3.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Autoconf-exception-generic",
-      "isDeprecatedLicenseId": false,
-      "name": "Autoconf generic exception",
-      "seeAlso": [
-        "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright",
-        "https://tracker.debian.org/media/packages/s/sipwitch/copyright-1.9.15-3",
-        "https://opensource.apple.com/source/launchd/launchd-258.1/launchd/compile.auto.html",
-        "https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=blob;f=gnulib-tool;h=029a8cf377ad8d8f2d9e54061bf2f20496ad2eef;hb=73c74ba0197e6566da6882c87b1adee63e24d75c#l407"
-      ],
-      "licenseComments": "Gnulib uses a variant wording of this exception.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Autoconf-exception-generic-3.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Autoconf generic exception for GPL-3.0",
-      "seeAlso": [
-        "https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/config.guess"
-      ],
-      "licenseComments": "This exception is the same as Autoconf-exception-generic, but it adds a sentence related to GPL-3.0.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "Autoconf-exception-macro",
-      "isDeprecatedLicenseId": false,
-      "name": "Autoconf macro exception",
-      "seeAlso": [
-        "https://github.com/freedesktop/xorg-macros/blob/39f07f7db58ebbf3dcb64a2bf9098ed5cf3d1223/xorg-macros.m4.in",
-        "https://www.gnu.org/software/autoconf-archive/ax_pthread.html",
-        "https://launchpad.net/ubuntu/precise/+source/xmltooling/+copyright"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Bison-exception-1.24",
-      "isDeprecatedLicenseId": false,
-      "name": "Bison exception 1.24",
-      "seeAlso": [
-        "https://github.com/arineng/rwhoisd/blob/master/rwhoisd/mkdb/y.tab.c#L180"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Bison-exception-2.2",
-      "isDeprecatedLicenseId": false,
-      "name": "Bison exception 2.2",
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later or GPL-3.0-only or GPL-3.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later",
-        "GPL-3.0-only",
-        "GPL-3.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Bootloader-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Bootloader Distribution Exception",
-      "seeAlso": [
-        "https://github.com/pyinstaller/pyinstaller/blob/develop/COPYING.txt"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "CGAL-linking-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "CGAL Linking Exception",
-      "seeAlso": [
-        "https://github.com/openscad/openscad/blob/openscad-2021.01/COPYING#L3",
-        "https://github.com/floriankirsch/OpenCSG/blob/opencsg-1-4-2-release/license.txt#L3"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Classpath-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Classpath exception 2.0",
-      "seeAlso": [
-        "http://www.gnu.org/software/classpath/license.html",
-        "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
-      ],
-      "licenseComments": "This is an exception from the FSF for Classpath. Independent-modules-exception is very similar, but has a separate id due to it being used with LGPL and a different lead-in that Classpath-exception-2.0.",
-      "relatedLicenses": [
-        "LGPL-2.0",
-        "LGPL-2.1",
-        "LGPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "CLISP-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "CLISP exception 2.0",
-      "seeAlso": [
-        "http://sourceforge.net/p/clisp/clisp/ci/default/tree/COPYRIGHT"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "cryptsetup-OpenSSL-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "cryptsetup OpenSSL exception",
-      "seeAlso": [
-        "https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/COPYING",
-        "https://gitlab.nic.cz/datovka/datovka/-/blob/develop/COPYING",
-        "https://github.com/nbs-system/naxsi/blob/951123ad456bdf5ac94e8d8819342fe3d49bc002/naxsi_src/naxsi_raw.c",
-        "http://web.mit.edu/jgross/arch/amd64_deb60/bin/mosh",
-        "https://sourceforge.net/p/linux-ima/ima-evm-utils/ci/master/tree/src/evmctl.c#l30"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "DigiRule-FOSS-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "DigiRule FOSS License Exception",
-      "seeAlso": [
-        "http://www.digirulesolutions.com/drupal/foss"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "eCos-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "eCos exception 2.0",
-      "seeAlso": [
-        "http://ecos.sourceware.org/license-overview.html"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later. Similar to Macro and Inlines Functions Exception",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "erlang-otp-linking-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Erlang/OTP Linking Exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs",
-        "https://erlang.org/pipermail/erlang-questions/2012-May/066355.html",
-        "https://gitea.osmocom.org/erlang/osmo_ss7/src/commit/2286c1b8738d715950026650bf53f19a69d6ed0e/src/ss7_links.erl#L20"
-      ],
-      "licenseComments": "This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL.",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "Fawkes-Runtime-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Fawkes Runtime Exception",
-      "seeAlso": [
-        "http://www.fawkesrobotics.org/about/license/"
-      ],
-      "licenseComments": "Combines the Classpath exception with the Macros and Inline Functions exception.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "FLTK-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "FLTK exception",
-      "seeAlso": [
-        "http://www.fltk.org/COPYING.php"
-      ],
-      "licenseComments": "Specified to be associated with LGPL-2.0-only. On Fedora List as \"FLTK License\".",
-      "relatedLicenses": [
-        "LGPL-2.0-only"
-      ]
-    },
-    {
-      "licenseExceptionId": "fmt-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "fmt exception",
-      "seeAlso": [
-        "https://github.com/fmtlib/fmt/blob/master/LICENSE",
-        "https://github.com/fmtlib/fmt/blob/2eb363297b24cd71a68ccfb20ff755430f17e60f/LICENSE#L22C1-L27C62"
-      ],
-      "licenseComments": "Typically used with MIT.",
-      "relatedLicenses": [
-        "MIT"
-      ]
-    },
-    {
-      "licenseExceptionId": "Font-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Font exception 2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "freertos-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "FreeRTOS Exception 2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20060809182744/http://www.freertos.org/a00114.html"
-      ],
-      "licenseComments": "This exception was used by the FreeRTOS project with GPL-2.0 until Amazon acquired the project and changed the license to MIT. Note, the exact text of the exception varied over the years and on different pages.",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "MIT"
-      ]
-    },
-    {
-      "licenseExceptionId": "GCC-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "GCC Runtime Library exception 2.0",
-      "seeAlso": [
-        "https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10",
-        "https://sourceware.org/git/?p=glibc.git;a=blob;f=csu/abi-note.c;h=c2ec208e94fbe91f63d3c375bd254b884695d190;hb=HEAD"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-or-later. Sometimes also referred to as \"linking exception.\"",
-      "relatedLicenses": [
-        "GPL-2.0-or-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "GCC-exception-2.0-note",
-      "isDeprecatedLicenseId": false,
-      "name": "GCC    Runtime Library exception 2.0 - note variant",
-      "seeAlso": [
-        "https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86_64/start.S"
-      ],
-      "licenseComments": "This is the same as GCC-exception-2.0 but adds a second paragraph.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "GCC-exception-3.1",
-      "isDeprecatedLicenseId": false,
-      "name": "GCC Runtime Library exception 3.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ],
-      "licenseComments": "Typically used with GPL-3.0-and-later",
-      "relatedLicenses": [
-        "GPL-3.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Gmsh-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Gmsh exception",
-      "seeAlso": [
-        "https://gitlab.onelab.info/gmsh/gmsh/-/raw/master/LICENSE.txt"
-      ],
-      "licenseComments": "This exception has been used with GPL-2.0",
-      "relatedLicenses": [
-        "GPL-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GNAT-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GNAT exception",
-      "seeAlso": [
-        "https://github.com/AdaCore/florist/blob/master/libsrc/posix-configurable_file_limits.adb"
-      ],
-      "licenseComments": "This exception has been used with both versions 2.0 and 3.0 of the GPL.",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GNOME-examples-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GNOME examples exception",
-      "seeAlso": [
-        "https://gitlab.gnome.org/Archive/gnome-devel-docs/-/blob/master/platform-demos/C/legal.xml?ref_type=heads",
-        "http://meldmerge.org/help/"
-      ],
-      "licenseComments": "This exception has been used with CC-BY-SA-3.0.",
-      "relatedLicenses": [
-        "CC-BY-SA-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GNU-compiler-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GNU Compiler Exception",
-      "seeAlso": [
-        "https://sourceware.org/git?p=binutils-gdb.git;a=blob;f=libiberty/unlink-if-ordinary.c;h=e49f2f2f67bfdb10d6b2bd579b0e01cad0fd708e;hb=HEAD#l19"
-      ],
-      "licenseComments": "This exception is the same as SWI-exception but delineates that the library is compiled with a GNU compiler, which is narrower than a or any free software compiler.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "gnu-javamail-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GNU JavaMail exception",
-      "seeAlso": [
-        "http://www.gnu.org/software/classpathx/javamail/javamail.html"
-      ],
-      "licenseComments": "Typically used with GPL (any version)",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GPL-3.0-389-ds-base-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GPL-3.0 389 DS Base Exception",
-      "seeAlso": [],
-      "licenseComments": "This exception is similar to GPL-3.0-linking-source-exception but applies to the \"licensed\" work, rather than the library.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GPL-3.0-interface-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GPL-3.0 Interface Exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.en.html#LinkingOverControlledInterface"
-      ],
-      "licenseComments": "This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL. This exception enables linking with differently licensed modules over the specified interface, while ensuring that users would still receive source code as they normally would under the GPL.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GPL-3.0-linking-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GPL-3.0 Linking Exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs"
-      ],
-      "licenseComments": "This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL. This variant does not include the second optional sentence regarding Corresponding Source. For a variant with that sentence, please see GPL-3.0-linking-source-exception.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GPL-3.0-linking-source-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "GPL-3.0 Linking Exception (with Corresponding Source)",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs",
-        "https://github.com/mirror/wget/blob/master/src/http.c#L20"
-      ],
-      "licenseComments": "This exception is based on the suggested template from the Free Software Foundation's FAQ about the GPL. This variant includes the second optional sentence regarding Corresponding Source. For a variant without that sentence, please see GPL-3.0-linking-exception.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GPL-CC-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "GPL Cooperation Commitment 1.0",
-      "seeAlso": [
-        "https://github.com/gplcc/gplcc/blob/master/Project/COMMITMENT",
-        "https://gplcc.github.io/gplcc/Project/README-PROJECT.html"
-      ],
-      "licenseComments": "This is the GPL Cooperation Commitment for projects. It is distinct from the GPL Cooperation Commitment for companies or individuals in that it applies at the project level for all contributions going forward as of the date it is adopted.",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "GStreamer-exception-2005",
-      "isDeprecatedLicenseId": false,
-      "name": "GStreamer Exception (2005)",
-      "seeAlso": [
-        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language=c#licensing-of-applications-using-gstreamer"
-      ],
-      "licenseComments": "This exception is the original exception added to the GNOME Videos (né totem\") project in 2005. Use GStreamer-exception-2008 instead.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "GStreamer-exception-2008",
-      "isDeprecatedLicenseId": false,
-      "name": "GStreamer Exception (2008)",
-      "seeAlso": [
-        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language=c#licensing-of-applications-using-gstreamer"
-      ],
-      "licenseComments": "This exception is based on the exception added to the GNOME Videos (né “totem”) project in 2005. Earlier versions of the exception had the project name hard-coded in the exception, and only implicitly mentioned the ability to reuse code without carrying the exception.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "harbour-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "harbour exception",
-      "seeAlso": [
-        "https://github.com/harbour/core/blob/master/LICENSE.txt#L44-L66"
-      ],
-      "licenseComments": "This exception has some similarities to SANE-exception. It is written to be used with GPL.",
-      "relatedLicenses": [
-        "GPL-2.0",
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "i2p-gpl-java-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "i2p GPL+Java Exception",
-      "seeAlso": [
-        "http://geti2p.net/en/get-involved/develop/licenses#java_exception"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Independent-modules-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Independent Module Linking exception",
-      "seeAlso": [
-        "https://gitlab.com/freepascal.org/fpc/source/-/blob/release_3_2_2/rtl/COPYING.FPC"
-      ],
-      "licenseComments": "The main part of this exception is essentially the same as Classpath-exception-2.0. However, due to it being used with LGPL and a different lead-in that Classpath-exception-2.0, it has its own id.",
-      "relatedLicenses": [
-        "LGPL-2.0",
-        "LGPL-2.1",
-        "LGPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "KiCad-libraries-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "KiCad Libraries Exception",
-      "seeAlso": [
-        "https://www.kicad.org/libraries/license/"
-      ],
-      "licenseComments": "Typically used with CC-BY-SA-4.0",
-      "relatedLicenses": [
-        "CC-BY-SA-4.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "LGPL-3.0-linking-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "LGPL-3.0 Linking Exception",
-      "seeAlso": [
-        "https://raw.githubusercontent.com/go-xmlpath/xmlpath/v2/LICENSE",
-        "https://github.com/goamz/goamz/blob/master/LICENSE",
-        "https://github.com/juju/errors/blob/master/LICENSE"
-      ],
-      "licenseComments": "Unlike GPL-3.0-linking-exception, this exception is not based on a suggested template from the Free Software Foundation's FAQ about the GPL. It is being added as it has been used in several projects as a linking exception to LGPL-3.0.",
-      "relatedLicenses": [
-        "LGPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "libpri-OpenH323-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "libpri OpenH323 exception",
-      "seeAlso": [
-        "https://github.com/asterisk/libpri/blob/1.6.0/README#L19-L22"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Libtool-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Libtool Exception",
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4",
-        "https://git.savannah.gnu.org/cgit/libtool.git/tree/libltdl/lt__alloc.c#n15"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Linux-syscall-note",
-      "isDeprecatedLicenseId": false,
-      "name": "Linux Syscall Note",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/COPYING"
-      ],
-      "licenseComments": "This note is used with the Linux kernel to clarify how user space API files should be treated.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "LLGPL",
-      "isDeprecatedLicenseId": false,
-      "name": "LLGPL Preamble",
-      "seeAlso": [
-        "http://opensource.franz.com/preamble.html"
-      ],
-      "licenseComments": "Typically used with LGPL-2.1",
-      "relatedLicenses": [
-        "LGPL-2.1"
-      ]
-    },
-    {
-      "licenseExceptionId": "LLVM-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "LLVM Exception",
-      "seeAlso": [
-        "http://llvm.org/foundation/relicensing/LICENSE.txt"
-      ],
-      "licenseComments": "This exception was created specifically to be used with Apache-2.0",
-      "relatedLicenses": [
-        "Apache-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "LZMA-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "LZMA exception",
-      "seeAlso": [
-        "http://nsis.sourceforge.net/Docs/AppendixI.html#I.6"
-      ],
-      "licenseComments": "Used by the LZMA compression module for NSIS to apply an exception to CPL-1.0",
-      "relatedLicenses": [
-        "CPL-1.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "mif-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Macros and Inline Functions Exception",
-      "seeAlso": [
-        "http://www.scs.stanford.edu/histar/src/lib/cppsup/exception",
-        "http://dev.bertos.org/doxygen/",
-        "https://www.threadingbuildingblocks.org/licensing"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later for older versions of GCC. This is similar to the eCos Exception.",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "mxml-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "mxml Exception",
-      "seeAlso": [
-        "https://github.com/michaelrsweet/mxml/blob/master/NOTICE",
-        "https://github.com/michaelrsweet/mxml/blob/master/LICENSE"
-      ],
-      "licenseComments": "This is similar to the LLVM-exception, but omits the first paragraph.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Nokia-Qt-exception-1.1",
-      "isDeprecatedLicenseId": true,
-      "name": "Nokia Qt LGPL exception 1.1",
-      "seeAlso": [
-        "https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION"
-      ],
-      "licenseComments": "DEPRECATED: Use Qt-LGPL-exception-1.1",
-      "relatedLicenses": [
-        "LGPL-2.0",
-        "LGPL-2.1",
-        "LGPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "OCaml-LGPL-linking-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "OCaml LGPL Linking Exception",
-      "seeAlso": [
-        "https://caml.inria.fr/ocaml/license.en.html"
-      ],
-      "licenseComments": "Adopted by OCaml core in 2001 here: https://github.com/ocaml/ocaml/commit/02ef950033b81fe371759f024faa55f361ba83a6#diff-9879d6db96fd29134fc802214163b95a (git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@4146 f963ae5c-01c2-4b8c-9fe0-0dff7051ff02) LGPL clause typo (was: 3; intended:2; fixed-to:2) fixed in 2007 here: https://github.com/ocaml/ocaml/commit/2d26308ad4d34ea0c00e44db62c4c24c7031c78c#diff-9879d6db96fd29134fc802214163b95a",
-      "relatedLicenses": [
-        "LGPL-2.0",
-        "LGPL-2.1",
-        "LGPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "OCCT-exception-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Open CASCADE Exception 1.0",
-      "seeAlso": [
-        "http://www.opencascade.com/content/licensing"
-      ],
-      "licenseComments": "Open CASCADE Technology version 6.7.0 and later are governed by (LGPL-2.1-only with this exception.) A specific license (OCCT-PL) is applied to Open CASCADE Technology version 6.6.0 and earlier.",
-      "relatedLicenses": [
-        "LGPL-2.1-only",
-        "OCCT-PL"
-      ]
-    },
-    {
-      "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "OpenJDK Assembly exception 1.0",
-      "seeAlso": [
-        "http://openjdk.java.net/legal/assembly-exception.html"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "openvpn-openssl-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "OpenVPN OpenSSL Exception",
-      "seeAlso": [
-        "http://openvpn.net/index.php/license.html",
-        "https://github.com/psycopg/psycopg2/blob/2_9_3/LICENSE#L14"
-      ],
-      "licenseComments": "Typically used with GPL 2.0",
-      "relatedLicenses": [
-        "GPL-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "PCRE2-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "PCRE2 exception",
-      "seeAlso": [
-        "https://www.pcre.org/licence.txt"
-      ],
-      "licenseComments": "This exception has been used with BSD-3-Clause.",
-      "relatedLicenses": [
-        "BSD-3-Clause"
-      ]
-    },
-    {
-      "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
-      "isDeprecatedLicenseId": false,
-      "name": "PS/PDF font exception (2017-08-17)",
-      "seeAlso": [
-        "https://github.com/ArtifexSoftware/urw-base35-fonts/blob/65962e27febc3883a17e651cdb23e783668c996f/LICENSE"
-      ],
-      "licenseComments": "Author-suggested standard header language recommends use with AGPL-3.0-only",
-      "relatedLicenses": [
-        "AGPL-3.0-only"
-      ]
-    },
-    {
-      "licenseExceptionId": "QPL-1.0-INRIA-2004-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "INRIA QPL 1.0 2004 variant exception",
-      "seeAlso": [
-        "https://git.frama-c.com/pub/frama-c/-/blob/master/licenses/Q_MODIFIED_LICENSE",
-        "https://github.com/maranget/hevea/blob/master/LICENSE"
-      ],
-      "licenseComments": "This exception is primarily used with QPL-1.0-INRIA-2004",
-      "relatedLicenses": [
-        "QPL-1.0-INRIA-2004"
-      ]
-    },
-    {
-      "licenseExceptionId": "Qt-GPL-exception-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Qt GPL exception 1.0",
-      "seeAlso": [
-        "http://code.qt.io/cgit/qt/qtbase.git/tree/LICENSE.GPL3-EXCEPT"
-      ],
-      "licenseComments": "Typically used with the GPL-3.0.",
-      "relatedLicenses": [
-        "GPL-3.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "Qt-LGPL-exception-1.1",
-      "isDeprecatedLicenseId": false,
-      "name": "Qt LGPL exception 1.1",
-      "seeAlso": [
-        "http://code.qt.io/cgit/qt/qtbase.git/tree/LGPL_EXCEPTION.txt"
-      ],
-      "licenseComments": "Used with LGPL-2.1-only, which is mentioned explicitly in the exception text.",
-      "relatedLicenses": [
-        "LGPL-2.1-only"
-      ]
-    },
-    {
-      "licenseExceptionId": "Qwt-exception-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Qwt exception 1.0",
-      "seeAlso": [
-        "http://qwt.sourceforge.net/qwtlicense.html"
-      ],
-      "licenseComments": "Specified to be associated with LGPL-2.1. On Fedora List as \"Qwt License 1.0\".",
-      "relatedLicenses": [
-        "LGPL-2.1"
-      ]
-    },
-    {
-      "licenseExceptionId": "romic-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Romic Exception",
-      "seeAlso": [
-        "https://web.archive.org/web/20210124015834/http://mo.morsi.org/blog/2009/08/13/lesser_affero_gplv3/",
-        "https://sourceforge.net/p/romic/code/ci/3ab2856180cf0d8b007609af53154cf092efc58f/tree/COPYING",
-        "https://github.com/moll/node-mitm/blob/bbf24b8bd7596dc6e091e625363161ce91984fc7/LICENSE#L8-L11",
-        "https://github.com/zenbones/SmallMind/blob/3c62b5995fe7f27c453f140ff9b60560a0893f2a/COPYRIGHT#L25-L30",
-        "https://github.com/CubeArtisan/cubeartisan/blob/2c6ab53455237b88a3ea07be02a838a135c4ab79/LICENSE.LESSER#L10-L15",
-        "https://github.com/savearray2/py.js/blob/b781273c08c8afa89f4954de4ecf42ec01429bae/README.md#license"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "RRDtool-FLOSS-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "RRDtool FLOSS exception 2.0",
-      "seeAlso": [
-        "https://github.com/oetiker/rrdtool-1.x/blob/master/COPYRIGHT#L25-L90",
-        "https://oss.oetiker.ch/rrdtool/license.en.html"
-      ],
-      "licenseComments": "This exception is generally used with GPL-2.0",
-      "relatedLicenses": [
-        "GPL-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "SANE-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "SANE Exception",
-      "seeAlso": [
-        "https://github.com/alexpevzner/sane-airscan/blob/master/LICENSE",
-        "https://gitlab.com/sane-project/backends/-/blob/master/sanei/sanei_pp.c?ref_type=heads",
-        "https://gitlab.com/sane-project/frontends/-/blob/master/sanei/sanei_codec_ascii.c?ref_type=heads"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "SHL-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Solderpad Hardware License v2.0",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-2.0/"
-      ],
-      "licenseComments": "Used with Apache-2.0. Italicized text from original license is not reflected in this copy but can be seen in license steward's version at https://solderpad.org/licenses/SHL-2.0/",
-      "relatedLicenses": [
-        "Apache-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "SHL-2.1",
-      "isDeprecatedLicenseId": false,
-      "name": "Solderpad Hardware License v2.1",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-2.1/"
-      ],
-      "licenseComments": "Used with Apache-2.0",
-      "relatedLicenses": [
-        "Apache-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "stunnel-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "stunnel Exception",
-      "seeAlso": [
-        "https://github.com/mtrojnar/stunnel/blob/master/COPYING.md"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "SWI-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "SWI exception",
-      "seeAlso": [
-        "https://github.com/SWI-Prolog/packages-clpqr/blob/bfa80b9270274f0800120d5b8e6fef42ac2dc6a5/clpqr/class.pl"
-      ],
-      "licenseComments": "This exception is closely similar to GNU-compiler-exception but delineates that the library is compiled with a Free Software compiler, which is slightly broader than a GNU compiler.",
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "Swift-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Swift Exception",
-      "seeAlso": [
-        "https://swift.org/LICENSE.txt",
-        "https://github.com/apple/swift-package-manager/blob/7ab2275f447a5eb37497ed63a9340f8a6d1e488b/LICENSE.txt#L205"
-      ],
-      "licenseComments": "This exception was created specifically to be used with Apache-2.0",
-      "relatedLicenses": [
-        "Apache-2.0"
-      ]
-    },
-    {
-      "licenseExceptionId": "Texinfo-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Texinfo exception",
-      "seeAlso": [
-        "https://git.savannah.gnu.org/cgit/automake.git/tree/lib/texinfo.tex?h=v1.16.5#n23"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "u-boot-exception-2.0",
-      "isDeprecatedLicenseId": false,
-      "name": "U-Boot exception 2.0",
-      "seeAlso": [
-        "http://git.denx.de/?p=u-boot.git;a=blob;f=Licenses/Exceptions"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "UBDL-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "Unmodified Binary Distribution exception",
-      "seeAlso": [
-        "https://github.com/ipxe/ipxe/blob/master/COPYING.UBDL"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-or-later",
-      "relatedLicenses": [
-        "GPL-2.0-or-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "Universal-FOSS-exception-1.0",
-      "isDeprecatedLicenseId": false,
-      "name": "Universal FOSS Exception, Version 1.0",
-      "seeAlso": [
-        "https://oss.oracle.com/licenses/universal-foss-exception/"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "vsftpd-openssl-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "vsftpd OpenSSL exception",
-      "seeAlso": [
-        "https://git.stg.centos.org/source-git/vsftpd/blob/f727873674d9c9cd7afcae6677aa782eb54c8362/f/LICENSE",
-        "https://launchpad.net/debian/squeeze/+source/vsftpd/+copyright",
-        "https://github.com/richardcochran/vsftpd/blob/master/COPYING"
-      ],
-      "relatedLicenses": []
-    },
-    {
-      "licenseExceptionId": "WxWindows-exception-3.1",
-      "isDeprecatedLicenseId": false,
-      "name": "WxWindows Library Exception 3.1",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
-      ],
-      "licenseComments": "Typically used with GPL-2.0-only or GPL-2.0-and-later",
-      "relatedLicenses": [
-        "GPL-2.0-only",
-        "GPL-2.0-and-later"
-      ]
-    },
-    {
-      "licenseExceptionId": "x11vnc-openssl-exception",
-      "isDeprecatedLicenseId": false,
-      "name": "x11vnc OpenSSL Exception",
-      "seeAlso": [
-        "https://github.com/LibVNC/x11vnc/blob/master/src/8to24.c#L22"
-      ],
-      "licenseComments": "This is very similar to openvpn-openssl-exception with a couple key differences.",
-      "relatedLicenses": []
-    }
-  ],
-  "releaseDate": "2025-05-12T00:00:00Z"
-}
+[
+  {
+    "name": "389 Directory Server Exception",
+    "licenseExceptionId": "389-exception",
+    "relatedLicenses": [
+      "GPL-2.0-only"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Asterisk exception",
+    "licenseExceptionId": "Asterisk-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Asterisk linking protocols exception",
+    "licenseExceptionId": "Asterisk-linking-protocols-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Autoconf exception 2.0",
+    "licenseExceptionId": "Autoconf-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Autoconf exception 3.0",
+    "licenseExceptionId": "Autoconf-exception-3.0",
+    "relatedLicenses": [
+      "GPL-3.0-only",
+      "GPL-3.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Autoconf generic exception",
+    "licenseExceptionId": "Autoconf-exception-generic",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Autoconf generic exception for GPL-3.0",
+    "licenseExceptionId": "Autoconf-exception-generic-3.0",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Autoconf macro exception",
+    "licenseExceptionId": "Autoconf-exception-macro",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Bison exception 1.24",
+    "licenseExceptionId": "Bison-exception-1.24",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Bison exception 2.2",
+    "licenseExceptionId": "Bison-exception-2.2",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later",
+      "GPL-3.0-only",
+      "GPL-3.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Bootloader Distribution Exception",
+    "licenseExceptionId": "Bootloader-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "CGAL Linking Exception",
+    "licenseExceptionId": "CGAL-linking-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Classpath exception 2.0",
+    "licenseExceptionId": "Classpath-exception-2.0",
+    "relatedLicenses": [
+      "LGPL-2.0",
+      "LGPL-2.1",
+      "LGPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "CLISP exception 2.0",
+    "licenseExceptionId": "CLISP-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "cryptsetup OpenSSL exception",
+    "licenseExceptionId": "cryptsetup-OpenSSL-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Digia Qt LGPL Exception version 1.1",
+    "licenseExceptionId": "Digia-Qt-LGPL-exception-1.1",
+    "relatedLicenses": [
+      "LGPL-2.0",
+      "LGPL-2.1",
+      "LGPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "DigiRule FOSS License Exception",
+    "licenseExceptionId": "DigiRule-FOSS-exception",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "eCos exception 2.0",
+    "licenseExceptionId": "eCos-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Erlang/OTP Linking Exception",
+    "licenseExceptionId": "erlang-otp-linking-exception",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Fawkes Runtime Exception",
+    "licenseExceptionId": "Fawkes-Runtime-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "FLTK exception",
+    "licenseExceptionId": "FLTK-exception",
+    "relatedLicenses": [
+      "LGPL-2.0-only"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "fmt exception",
+    "licenseExceptionId": "fmt-exception",
+    "relatedLicenses": [
+      "MIT"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Font exception 2.0",
+    "licenseExceptionId": "Font-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "FreeRTOS Exception 2.0",
+    "licenseExceptionId": "freertos-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "MIT"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GCC Runtime Library exception 2.0",
+    "licenseExceptionId": "GCC-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GCC    Runtime Library exception 2.0 - note variant",
+    "licenseExceptionId": "GCC-exception-2.0-note",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "GCC Runtime Library exception 3.1",
+    "licenseExceptionId": "GCC-exception-3.1",
+    "relatedLicenses": [
+      "GPL-3.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Gmsh exception",
+    "licenseExceptionId": "Gmsh-exception",
+    "relatedLicenses": [
+      "GPL-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GNAT exception",
+    "licenseExceptionId": "GNAT-exception",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GNOME examples exception",
+    "licenseExceptionId": "GNOME-examples-exception",
+    "relatedLicenses": [
+      "CC-BY-SA-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GNU Compiler Exception",
+    "licenseExceptionId": "GNU-compiler-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "GNU JavaMail exception",
+    "licenseExceptionId": "gnu-javamail-exception",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GPL-3.0 389 DS Base Exception",
+    "licenseExceptionId": "GPL-3.0-389-ds-base-exception",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GPL-3.0 Interface Exception",
+    "licenseExceptionId": "GPL-3.0-interface-exception",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GPL-3.0 Linking Exception",
+    "licenseExceptionId": "GPL-3.0-linking-exception",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GPL-3.0 Linking Exception (with Corresponding Source)",
+    "licenseExceptionId": "GPL-3.0-linking-source-exception",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GPL Cooperation Commitment 1.0",
+    "licenseExceptionId": "GPL-CC-1.0",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "GStreamer Exception (2005)",
+    "licenseExceptionId": "GStreamer-exception-2005",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "GStreamer Exception (2008)",
+    "licenseExceptionId": "GStreamer-exception-2008",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "harbour exception",
+    "licenseExceptionId": "harbour-exception",
+    "relatedLicenses": [
+      "GPL-2.0",
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "i2p GPL+Java Exception",
+    "licenseExceptionId": "i2p-gpl-java-exception",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Independent Module Linking exception",
+    "licenseExceptionId": "Independent-modules-exception",
+    "relatedLicenses": [
+      "LGPL-2.0",
+      "LGPL-2.1",
+      "LGPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "KiCad Libraries Exception",
+    "licenseExceptionId": "KiCad-libraries-exception",
+    "relatedLicenses": [
+      "CC-BY-SA-4.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "LGPL-3.0 Linking Exception",
+    "licenseExceptionId": "LGPL-3.0-linking-exception",
+    "relatedLicenses": [
+      "LGPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "libpri OpenH323 exception",
+    "licenseExceptionId": "libpri-OpenH323-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Libtool Exception",
+    "licenseExceptionId": "Libtool-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Linux Syscall Note",
+    "licenseExceptionId": "Linux-syscall-note",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "LLGPL Preamble",
+    "licenseExceptionId": "LLGPL",
+    "relatedLicenses": [
+      "LGPL-2.1"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "LLVM Exception",
+    "licenseExceptionId": "LLVM-exception",
+    "relatedLicenses": [
+      "Apache-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "LZMA exception",
+    "licenseExceptionId": "LZMA-exception",
+    "relatedLicenses": [
+      "CPL-1.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Macros and Inline Functions Exception",
+    "licenseExceptionId": "mif-exception",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "mxml Exception",
+    "licenseExceptionId": "mxml-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Nokia Qt LGPL exception 1.1",
+    "licenseExceptionId": "Nokia-Qt-exception-1.1",
+    "relatedLicenses": [
+      "LGPL-2.0",
+      "LGPL-2.1",
+      "LGPL-3.0"
+    ],
+    "deprecated": true
+  },
+  {
+    "name": "OCaml LGPL Linking Exception",
+    "licenseExceptionId": "OCaml-LGPL-linking-exception",
+    "relatedLicenses": [
+      "LGPL-2.0",
+      "LGPL-2.1",
+      "LGPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Open CASCADE Exception 1.0",
+    "licenseExceptionId": "OCCT-exception-1.0",
+    "relatedLicenses": [
+      "LGPL-2.1-only",
+      "OCCT-PL"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "OpenJDK Assembly exception 1.0",
+    "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "OpenVPN OpenSSL Exception",
+    "licenseExceptionId": "openvpn-openssl-exception",
+    "relatedLicenses": [
+      "GPL-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "PCRE2 exception",
+    "licenseExceptionId": "PCRE2-exception",
+    "relatedLicenses": [
+      "BSD-3-Clause"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Polyparse Exception",
+    "licenseExceptionId": "polyparse-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "PS/PDF font exception (2017-08-17)",
+    "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
+    "relatedLicenses": [
+      "AGPL-3.0-only"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "INRIA QPL 1.0 2004 variant exception",
+    "licenseExceptionId": "QPL-1.0-INRIA-2004-exception",
+    "relatedLicenses": [
+      "QPL-1.0-INRIA-2004"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Qt GPL exception 1.0",
+    "licenseExceptionId": "Qt-GPL-exception-1.0",
+    "relatedLicenses": [
+      "GPL-3.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Qt LGPL exception 1.1",
+    "licenseExceptionId": "Qt-LGPL-exception-1.1",
+    "relatedLicenses": [
+      "LGPL-2.1-only"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Qwt exception 1.0",
+    "licenseExceptionId": "Qwt-exception-1.0",
+    "relatedLicenses": [
+      "LGPL-2.1"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Romic Exception",
+    "licenseExceptionId": "romic-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "RRDtool FLOSS exception 2.0",
+    "licenseExceptionId": "RRDtool-FLOSS-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "SANE Exception",
+    "licenseExceptionId": "SANE-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Solderpad Hardware License v2.0",
+    "licenseExceptionId": "SHL-2.0",
+    "relatedLicenses": [
+      "Apache-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Solderpad Hardware License v2.1",
+    "licenseExceptionId": "SHL-2.1",
+    "relatedLicenses": [
+      "Apache-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "stunnel Exception",
+    "licenseExceptionId": "stunnel-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "SWI exception",
+    "licenseExceptionId": "SWI-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "Swift Exception",
+    "licenseExceptionId": "Swift-exception",
+    "relatedLicenses": [
+      "Apache-2.0"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Texinfo exception",
+    "licenseExceptionId": "Texinfo-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "U-Boot exception 2.0",
+    "licenseExceptionId": "u-boot-exception-2.0",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Unmodified Binary Distribution exception",
+    "licenseExceptionId": "UBDL-exception",
+    "relatedLicenses": [
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "Universal FOSS Exception, Version 1.0",
+    "licenseExceptionId": "Universal-FOSS-exception-1.0",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "vsftpd OpenSSL exception",
+    "licenseExceptionId": "vsftpd-openssl-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  },
+  {
+    "name": "WxWindows Library Exception 3.1",
+    "licenseExceptionId": "WxWindows-exception-3.1",
+    "relatedLicenses": [
+      "GPL-2.0-only",
+      "GPL-2.0-or-later"
+    ],
+    "deprecated": false
+  },
+  {
+    "name": "x11vnc OpenSSL Exception",
+    "licenseExceptionId": "x11vnc-openssl-exception",
+    "relatedLicenses": [],
+    "deprecated": false
+  }
+]

--- a/src/codegen/licenses.json
+++ b/src/codegen/licenses.json
@@ -1,7026 +1,3492 @@
-{
-  "licenseListVersion": "21b8e53",
-  "licenses": [
-    {
-      "name": "BSD Zero Clause License",
-      "licenseId": "0BSD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://landley.net/toybox/license.html",
-        "https://opensource.org/licenses/0BSD"
-      ]
-    },
-    {
-      "name": "3D Slicer License v1.0",
-      "licenseId": "3D-Slicer-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://slicer.org/LICENSE",
-        "https://github.com/Slicer/Slicer/blob/main/License.txt"
-      ]
-    },
-    {
-      "name": "Attribution Assurance License",
-      "licenseId": "AAL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/attribution"
-      ]
-    },
-    {
-      "name": "Abstyles License",
-      "licenseId": "Abstyles",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Abstyles"
-      ]
-    },
-    {
-      "name": "AdaCore Doc License",
-      "licenseId": "AdaCore-doc",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/AdaCore/xmlada/blob/master/docs/index.rst",
-        "https://github.com/AdaCore/gnatcoll-core/blob/master/docs/index.rst",
-        "https://github.com/AdaCore/gnatcoll-db/blob/master/docs/index.rst"
-      ]
-    },
-    {
-      "name": "Adobe Systems Incorporated Source Code License Agreement",
-      "licenseId": "Adobe-2006",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
-      ]
-    },
-    {
-      "name": "Adobe Display PostScript License",
-      "licenseId": "Adobe-Display-PostScript",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L752"
-      ]
-    },
-    {
-      "name": "Adobe Glyph List License",
-      "licenseId": "Adobe-Glyph",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
-      ]
-    },
-    {
-      "name": "Adobe Utopia Font License",
-      "licenseId": "Adobe-Utopia",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-100dpi/-/blob/master/COPYING?ref_type=heads"
-      ]
-    },
-    {
-      "name": "Amazon Digital Services License",
-      "licenseId": "ADSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
-      ]
-    },
-    {
-      "name": "Academic Free License v1.1",
-      "licenseId": "AFL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
-        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
-      ]
-    },
-    {
-      "name": "Academic Free License v1.2",
-      "licenseId": "AFL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
-        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
-      ]
-    },
-    {
-      "name": "Academic Free License v2.0",
-      "licenseId": "AFL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
-      ]
-    },
-    {
-      "name": "Academic Free License v2.1",
-      "licenseId": "AFL-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
-      ]
-    },
-    {
-      "name": "Academic Free License v3.0",
-      "licenseId": "AFL-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.rosenlaw.com/AFL3.0.htm",
-        "https://opensource.org/licenses/afl-3.0"
-      ]
-    },
-    {
-      "name": "Afmparse License",
-      "licenseId": "Afmparse",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Afmparse"
-      ]
-    },
-    {
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ]
-    },
-    {
-      "name": "Affero General Public License v1.0 only",
-      "licenseId": "AGPL-1.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ]
-    },
-    {
-      "name": "Affero General Public License v1.0 or later",
-      "licenseId": "AGPL-1.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ]
-    },
-    {
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU Affero General Public License v3.0 only",
-      "licenseId": "AGPL-3.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU Affero General Public License v3.0 or later",
-      "licenseId": "AGPL-3.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ]
-    },
-    {
-      "name": "Aladdin Free Public License",
-      "licenseId": "Aladdin",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
-      ]
-    },
-    {
-      "name": "AMD newlib License",
-      "licenseId": "AMD-newlib",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/sys/a29khif/_close.S;h=04f52ae00de1dafbd9055ad8d73c5c697a3aae7f;hb=HEAD"
-      ]
-    },
-    {
-      "name": "AMD's plpa_map.c License",
-      "licenseId": "AMDPLPA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
-      ]
-    },
-    {
-      "name": "Apple MIT License",
-      "licenseId": "AML",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
-      ]
-    },
-    {
-      "name": "AML glslang variant License",
-      "licenseId": "AML-glslang",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/KhronosGroup/glslang/blob/main/LICENSE.txt#L949",
-        "https://docs.omniverse.nvidia.com/install-guide/latest/common/licenses.html"
-      ]
-    },
-    {
-      "name": "Academy of Motion Picture Arts and Sciences BSD",
-      "licenseId": "AMPAS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
-      ]
-    },
-    {
-      "name": "ANTLR Software Rights Notice",
-      "licenseId": "ANTLR-PD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.antlr2.org/license.html"
-      ]
-    },
-    {
-      "name": "ANTLR Software Rights Notice with license fallback",
-      "licenseId": "ANTLR-PD-fallback",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.antlr2.org/license.html"
-      ]
-    },
-    {
-      "name": "Any OSI License",
-      "licenseId": "any-OSI",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/pod/Exporter::Tidy#LICENSE"
-      ]
-    },
-    {
-      "name": "Any OSI License - Perl Modules",
-      "licenseId": "any-OSI-perl-modules",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/release/JUERD/Exporter-Tidy-0.09/view/Tidy.pm#LICENSE",
-        "https://metacpan.org/pod/Qmail::Deliverable::Client#LICENSE",
-        "https://metacpan.org/pod/Net::MQTT::Simple#LICENSE"
-      ]
-    },
-    {
-      "name": "Apache License 1.0",
-      "licenseId": "Apache-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-1.0"
-      ]
-    },
-    {
-      "name": "Apache License 1.1",
-      "licenseId": "Apache-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://apache.org/licenses/LICENSE-1.1",
-        "https://opensource.org/licenses/Apache-1.1"
-      ]
-    },
-    {
-      "name": "Apache License 2.0",
-      "licenseId": "Apache-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.apache.org/licenses/LICENSE-2.0",
-        "https://opensource.org/licenses/Apache-2.0"
-      ]
-    },
-    {
-      "name": "Adobe Postscript AFM License",
-      "licenseId": "APAFML",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
-      ]
-    },
-    {
-      "name": "Adaptive Public License 1.0",
-      "licenseId": "APL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/APL-1.0"
-      ]
-    },
-    {
-      "name": "App::s2p License",
-      "licenseId": "App-s2p",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/App-s2p"
-      ]
-    },
-    {
-      "name": "Apple Public Source License 1.0",
-      "licenseId": "APSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
-      ]
-    },
-    {
-      "name": "Apple Public Source License 1.1",
-      "licenseId": "APSL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
-      ]
-    },
-    {
-      "name": "Apple Public Source License 1.2",
-      "licenseId": "APSL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
-      ]
-    },
-    {
-      "name": "Apple Public Source License 2.0",
-      "licenseId": "APSL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.opensource.apple.com/license/apsl/"
-      ]
-    },
-    {
-      "name": "Arphic Public License",
-      "licenseId": "Arphic-1999",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
-      ]
-    },
-    {
-      "name": "Artistic License 1.0",
-      "licenseId": "Artistic-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
-      ]
-    },
-    {
-      "name": "Artistic License 1.0 w/clause 8",
-      "licenseId": "Artistic-1.0-cl8",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
-      ]
-    },
-    {
-      "name": "Artistic License 1.0 (Perl)",
-      "licenseId": "Artistic-1.0-Perl",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://dev.perl.org/licenses/artistic.html"
-      ]
-    },
-    {
-      "name": "Artistic License 2.0",
-      "licenseId": "Artistic-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.perlfoundation.org/artistic_license_2_0",
-        "https://www.perlfoundation.org/artistic-license-20.html",
-        "https://opensource.org/licenses/artistic-license-2.0"
-      ]
-    },
-    {
-      "name": "ASWF Digital Assets License version 1.0",
-      "licenseId": "ASWF-Digital-Assets-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.0.txt"
-      ]
-    },
-    {
-      "name": "ASWF Digital Assets License 1.1",
-      "licenseId": "ASWF-Digital-Assets-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.1.txt"
-      ]
-    },
-    {
-      "name": "Baekmuk License",
-      "licenseId": "Baekmuk",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:Baekmuk?rd=Licensing/Baekmuk"
-      ]
-    },
-    {
-      "name": "Bahyph License",
-      "licenseId": "Bahyph",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Bahyph"
-      ]
-    },
-    {
-      "name": "Barr License",
-      "licenseId": "Barr",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Barr"
-      ]
-    },
-    {
-      "name": "bcrypt Solar Designer License",
-      "licenseId": "bcrypt-Solar-Designer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/mri/crypt_blowfish.c"
-      ]
-    },
-    {
-      "name": "Beerware License",
-      "licenseId": "Beerware",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Beerware",
-        "https://people.freebsd.org/~phk/"
-      ]
-    },
-    {
-      "name": "Bitstream Charter Font License",
-      "licenseId": "Bitstream-Charter",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Charter#License_Text",
-        "https://raw.githubusercontent.com/blackhole89/notekit/master/data/fonts/Charter%20license.txt"
-      ]
-    },
-    {
-      "name": "Bitstream Vera Font License",
-      "licenseId": "Bitstream-Vera",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://web.archive.org/web/20080207013128/http://www.gnome.org/fonts/",
-        "https://docubrain.com/sites/default/files/licenses/bitstream-vera.html"
-      ]
-    },
-    {
-      "name": "BitTorrent Open Source License v1.0",
-      "licenseId": "BitTorrent-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s"
-      ]
-    },
-    {
-      "name": "BitTorrent Open Source License v1.1",
-      "licenseId": "BitTorrent-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
-      ]
-    },
-    {
-      "name": "SQLite Blessing",
-      "licenseId": "blessing",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln=4-9",
-        "https://sqlite.org/src/artifact/df5091916dbb40e6"
-      ]
-    },
-    {
-      "name": "Blue Oak Model License 1.0.0",
-      "licenseId": "BlueOak-1.0.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://blueoakcouncil.org/license/1.0.0"
-      ]
-    },
-    {
-      "name": "Boehm-Demers-Weiser GC License",
-      "licenseId": "Boehm-GC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT#Another_Minimal_variant_(found_in_libatomic_ops)",
-        "https://github.com/uim/libgcroots/blob/master/COPYING",
-        "https://github.com/ivmai/libatomic_ops/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "Boehm-Demers-Weiser GC License (without fee)",
-      "licenseId": "Boehm-GC-without-fee",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/MariaDB/server/blob/11.6/libmysqld/lib_sql.cc"
-      ]
-    },
-    {
-      "name": "Borceux license",
-      "licenseId": "Borceux",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Borceux"
-      ]
-    },
-    {
-      "name": "Brian Gladman 2-Clause License",
-      "licenseId": "Brian-Gladman-2-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L140-L156",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
-      ]
-    },
-    {
-      "name": "Brian Gladman 3-Clause License",
-      "licenseId": "Brian-Gladman-3-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/SWI-Prolog/packages-clib/blob/master/sha1/brg_endian.h"
-      ]
-    },
-    {
-      "name": "BSD 1-Clause License",
-      "licenseId": "BSD-1-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/BSD-2-Clause"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause - Ian Darwin variant",
-      "licenseId": "BSD-2-Clause-Darwin",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/file/file/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause - first lines requirement",
-      "licenseId": "BSD-2-Clause-first-lines",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L664-L690",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause FreeBSD License",
-      "licenseId": "BSD-2-Clause-FreeBSD",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause NetBSD License",
-      "licenseId": "BSD-2-Clause-NetBSD",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.netbsd.org/about/redistribution.html#default"
-      ]
-    },
-    {
-      "name": "BSD-2-Clause Plus Patent License",
-      "licenseId": "BSD-2-Clause-Patent",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/BSDplusPatent"
-      ]
-    },
-    {
-      "name": "BSD 2-Clause with views sentence",
-      "licenseId": "BSD-2-Clause-Views",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html",
-        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
-        "https://github.com/protegeproject/protege/blob/master/license.txt"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/BSD-3-Clause",
-        "https://www.eclipse.org/org/documents/edl-v10.php"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause acpica variant",
-      "licenseId": "BSD-3-Clause-acpica",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/acpica/acpica/blob/master/source/common/acfileio.c#L119"
-      ]
-    },
-    {
-      "name": "BSD with attribution",
-      "licenseId": "BSD-3-Clause-Attribution",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause Clear License",
-      "licenseId": "BSD-3-Clause-Clear",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://labs.metacarta.com/license-explanation.html#license"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause Flex variant",
-      "licenseId": "BSD-3-Clause-flex",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/westes/flex/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "Hewlett-Packard BSD variant license",
-      "licenseId": "BSD-3-Clause-HP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/zdohnal/hplip/blob/master/COPYING#L939"
-      ]
-    },
-    {
-      "name": "Lawrence Berkeley National Labs BSD variant license",
-      "licenseId": "BSD-3-Clause-LBNL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause Modification",
-      "licenseId": "BSD-3-Clause-Modification",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause No Military License",
-      "licenseId": "BSD-3-Clause-No-Military-License",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.syncad.com/hive/dhive/-/blob/master/LICENSE",
-        "https://github.com/greymass/swift-eosio/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause No Nuclear License",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause No Nuclear Warranty",
-      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://jogamp.org/git/?p=gluegen.git;a=blob_plain;f=LICENSE.txt"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause Open MPI variant",
-      "licenseId": "BSD-3-Clause-Open-MPI",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.open-mpi.org/community/license.php",
-        "http://www.netlib.org/lapack/LICENSE.txt"
-      ]
-    },
-    {
-      "name": "BSD 3-Clause Sun Microsystems",
-      "licenseId": "BSD-3-Clause-Sun",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/xmlark/msv/blob/b9316e2f2270bc1606952ea4939ec87fbba157f3/xsdlib/src/main/java/com/sun/msv/datatype/regexp/InternalImpl.java"
-      ]
-    },
-    {
-      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
-      "licenseId": "BSD-4-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BSD_4Clause"
-      ]
-    },
-    {
-      "name": "BSD 4 Clause Shortened",
-      "licenseId": "BSD-4-Clause-Shortened",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
-      ]
-    },
-    {
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
-      ]
-    },
-    {
-      "name": "BSD 4.3 RENO License",
-      "licenseId": "BSD-4.3RENO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=libiberty/strcasecmp.c;h=131d81c2ce7881fa48c363dc5bf5fb302c61ce0b;hb=HEAD",
-        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT#L55-63"
-      ]
-    },
-    {
-      "name": "BSD 4.3 TAHOE License",
-      "licenseId": "BSD-4.3TAHOE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/389ds/389-ds-base/blob/main/ldap/include/sysexits-compat.h#L15",
-        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id=a74c6b4ee49397cf330b333da1042bffa60ed14f#n1788"
-      ]
-    },
-    {
-      "name": "BSD Advertising Acknowledgement License",
-      "licenseId": "BSD-Advertising-Acknowledgement",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/python-excel/xlrd/blob/master/LICENSE#L33"
-      ]
-    },
-    {
-      "name": "BSD with Attribution and HPND disclaimer",
-      "licenseId": "BSD-Attribution-HPND-disclaimer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/cyrusimap/cyrus-sasl/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "BSD-Inferno-Nettverk",
-      "licenseId": "BSD-Inferno-Nettverk",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.inet.no/dante/LICENSE"
-      ]
-    },
-    {
-      "name": "BSD Protection License",
-      "licenseId": "BSD-Protection",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
-      ]
-    },
-    {
-      "name": "BSD Source Code Attribution - beginning of file variant",
-      "licenseId": "BSD-Source-beginning-file",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/lattera/freebsd/blob/master/sys/cam/cam.c#L4"
-      ]
-    },
-    {
-      "name": "BSD Source Code Attribution",
-      "licenseId": "BSD-Source-Code",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
-      ]
-    },
-    {
-      "name": "Systemics BSD variant license",
-      "licenseId": "BSD-Systemics",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/release/DPARIS/Crypt-DES-2.07/source/COPYRIGHT"
-      ]
-    },
-    {
-      "name": "Systemics W3Works BSD variant license",
-      "licenseId": "BSD-Systemics-W3Works",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/release/DPARIS/Crypt-Blowfish-2.14/source/COPYRIGHT#L7"
-      ]
-    },
-    {
-      "name": "Boost Software License 1.0",
-      "licenseId": "BSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.boost.org/LICENSE_1_0.txt",
-        "https://opensource.org/licenses/BSL-1.0"
-      ]
-    },
-    {
-      "name": "Business Source License 1.1",
-      "licenseId": "BUSL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://mariadb.com/bsl11/"
-      ]
-    },
-    {
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
-      ]
-    },
-    {
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6",
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html",
-        "https://sourceware.org/cgit/valgrind/tree/mpi/libmpiwrap.c"
-      ]
-    },
-    {
-      "name": "Computational Use of Data Agreement v1.0",
-      "licenseId": "C-UDA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
-        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
-      ]
-    },
-    {
-      "name": "Cryptographic Autonomy License 1.0",
-      "licenseId": "CAL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
-      ]
-    },
-    {
-      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
-      "licenseId": "CAL-1.0-Combined-Work-Exception",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
-      ]
-    },
-    {
-      "name": "Caldera License",
-      "licenseId": "Caldera",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
-      ]
-    },
-    {
-      "name": "Caldera License (without preamble)",
-      "licenseId": "Caldera-no-preamble",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/apache/apr/blob/trunk/LICENSE#L298C6-L298C29"
-      ]
-    },
-    {
-      "name": "Catharon License",
-      "licenseId": "Catharon",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/scummvm/scummvm/blob/v2.8.0/LICENSES/CatharonLicense.txt"
-      ]
-    },
-    {
-      "name": "Computer Associates Trusted Open Source License 1.1",
-      "licenseId": "CATOSL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/CATOSL-1.1"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 1.0 Generic",
-      "licenseId": "CC-BY-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 2.0 Generic",
-      "licenseId": "CC-BY-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 2.5 Generic",
-      "licenseId": "CC-BY-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 2.5 Australia",
-      "licenseId": "CC-BY-2.5-AU",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.5/au/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 Unported",
-      "licenseId": "CC-BY-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 Austria",
-      "licenseId": "CC-BY-3.0-AT",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 Australia",
-      "licenseId": "CC-BY-3.0-AU",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/au/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 Germany",
-      "licenseId": "CC-BY-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 IGO",
-      "licenseId": "CC-BY-3.0-IGO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/igo/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 Netherlands",
-      "licenseId": "CC-BY-3.0-NL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/nl/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 3.0 United States",
-      "licenseId": "CC-BY-3.0-US",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution 4.0 International",
-      "licenseId": "CC-BY-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
-      "licenseId": "CC-BY-NC-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
-      "licenseId": "CC-BY-NC-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
-      "licenseId": "CC-BY-NC-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
-      "licenseId": "CC-BY-NC-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
-      "licenseId": "CC-BY-NC-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial 4.0 International",
-      "licenseId": "CC-BY-NC-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
-      "licenseId": "CC-BY-NC-ND-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-NC-ND-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-NC-ND-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-NC-ND-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
-      "licenseId": "CC-BY-NC-ND-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
-      "licenseId": "CC-BY-NC-ND-3.0-IGO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
-      "licenseId": "CC-BY-NC-ND-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-NC-SA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-NC-SA-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
-      "licenseId": "CC-BY-NC-SA-2.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
-      "licenseId": "CC-BY-NC-SA-2.0-FR",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/fr/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
-      "licenseId": "CC-BY-NC-SA-2.0-UK",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/uk/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-NC-SA-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-NC-SA-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
-      "licenseId": "CC-BY-NC-SA-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
-      "licenseId": "CC-BY-NC-SA-3.0-IGO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/igo/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
-      "licenseId": "CC-BY-NC-SA-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
-      "licenseId": "CC-BY-ND-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-ND-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-ND-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-ND-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
-      "licenseId": "CC-BY-ND-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution No Derivatives 4.0 International",
-      "licenseId": "CC-BY-ND-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-SA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-SA-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
-      "licenseId": "CC-BY-SA-2.0-UK",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
-      "licenseId": "CC-BY-SA-2.1-JP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-SA-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-SA-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 3.0 Austria",
-      "licenseId": "CC-BY-SA-3.0-AT",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 3.0 Germany",
-      "licenseId": "CC-BY-SA-3.0-DE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/de/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
-      "licenseId": "CC-BY-SA-3.0-IGO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/igo/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Attribution Share Alike 4.0 International",
-      "licenseId": "CC-BY-SA-4.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Public Domain Dedication and Certification",
-      "licenseId": "CC-PDDC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/publicdomain/"
-      ]
-    },
-    {
-      "name": "Creative    Commons Public Domain Mark 1.0 Universal",
-      "licenseId": "CC-PDM-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/publicdomain/mark/1.0/",
-        "https://creativecommons.org/share-your-work/cclicenses/"
-      ]
-    },
-    {
-      "name": "Creative Commons Share Alike 1.0 Generic",
-      "licenseId": "CC-SA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://creativecommons.org/licenses/sa/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Creative Commons Zero v1.0 Universal",
-      "licenseId": "CC0-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
-      ]
-    },
-    {
-      "name": "Common Development and Distribution License 1.0",
-      "licenseId": "CDDL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/cddl1"
-      ]
-    },
-    {
-      "name": "Common Development and Distribution License 1.1",
-      "licenseId": "CDDL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
-        "https://javaee.github.io/glassfish/LICENSE"
-      ]
-    },
-    {
-      "name": "Common Documentation License 1.0",
-      "licenseId": "CDL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.opensource.apple.com/cdl/",
-        "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License",
-        "https://www.gnu.org/licenses/license-list.html#ACDL"
-      ]
-    },
-    {
-      "name": "Community Data License Agreement Permissive 1.0",
-      "licenseId": "CDLA-Permissive-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://cdla.io/permissive-1-0"
-      ]
-    },
-    {
-      "name": "Community Data License Agreement Permissive 2.0",
-      "licenseId": "CDLA-Permissive-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://cdla.dev/permissive-2-0"
-      ]
-    },
-    {
-      "name": "Community Data License Agreement Sharing 1.0",
-      "licenseId": "CDLA-Sharing-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://cdla.io/sharing-1-0"
-      ]
-    },
-    {
-      "name": "CeCILL Free Software License Agreement v1.0",
-      "licenseId": "CECILL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
-      ]
-    },
-    {
-      "name": "CeCILL Free Software License Agreement v1.1",
-      "licenseId": "CECILL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
-      ]
-    },
-    {
-      "name": "CeCILL Free Software License Agreement v2.0",
-      "licenseId": "CECILL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
-      ]
-    },
-    {
-      "name": "CeCILL Free Software License Agreement v2.1",
-      "licenseId": "CECILL-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
-      ]
-    },
-    {
-      "name": "CeCILL-B Free Software License Agreement",
-      "licenseId": "CECILL-B",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
-      ]
-    },
-    {
-      "name": "CeCILL-C Free Software License Agreement",
-      "licenseId": "CECILL-C",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
-      ]
-    },
-    {
-      "name": "CERN Open Hardware Licence v1.1",
-      "licenseId": "CERN-OHL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1"
-      ]
-    },
-    {
-      "name": "CERN Open Hardware Licence v1.2",
-      "licenseId": "CERN-OHL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
-      ]
-    },
-    {
-      "name": "CERN Open Hardware Licence Version 2 - Permissive",
-      "licenseId": "CERN-OHL-P-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ]
-    },
-    {
-      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
-      "licenseId": "CERN-OHL-S-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ]
-    },
-    {
-      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
-      "licenseId": "CERN-OHL-W-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ]
-    },
-    {
-      "name": "CFITSIO License",
-      "licenseId": "CFITSIO",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/f_user/node9.html",
-        "https://heasarc.gsfc.nasa.gov/docs/software/ftools/fv/doc/license.html"
-      ]
-    },
-    {
-      "name": "check-cvs License",
-      "licenseId": "check-cvs",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://cvs.savannah.gnu.org/viewvc/cvs/ccvs/contrib/check_cvs.in?revision=1.1.4.3&view=markup&pathrev=cvs1-11-23#l2"
-      ]
-    },
-    {
-      "name": "Checkmk License",
-      "licenseId": "checkmk",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/libcheck/check/blob/master/checkmk/checkmk.in"
-      ]
-    },
-    {
-      "name": "Clarified Artistic License",
-      "licenseId": "ClArtistic",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
-        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
-      ]
-    },
-    {
-      "name": "Clips License",
-      "licenseId": "Clips",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/DrItanium/maya/blob/master/LICENSE.CLIPS"
-      ]
-    },
-    {
-      "name": "CMU Mach License",
-      "licenseId": "CMU-Mach",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.cs.cmu.edu/~410/licenses.html"
-      ]
-    },
-    {
-      "name": "CMU    Mach - no notices-in-documentation variant",
-      "licenseId": "CMU-Mach-nodoc",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L718-L728",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
-      ]
-    },
-    {
-      "name": "CNRI Jython License",
-      "licenseId": "CNRI-Jython",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.jython.org/license.html"
-      ]
-    },
-    {
-      "name": "CNRI Python License",
-      "licenseId": "CNRI-Python",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/CNRI-Python"
-      ]
-    },
-    {
-      "name": "CNRI Python Open Source GPL Compatible License Agreement",
-      "licenseId": "CNRI-Python-GPL-Compatible",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.python.org/download/releases/1.6.1/download_win/"
-      ]
-    },
-    {
-      "name": "Copyfree Open Innovation License",
-      "licenseId": "COIL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://coil.apotheon.org/plaintext/01.0.txt"
-      ]
-    },
-    {
-      "name": "Community Specification License 1.0",
-      "licenseId": "Community-Spec-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md"
-      ]
-    },
-    {
-      "name": "Condor Public License v1.1",
-      "licenseId": "Condor-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://research.cs.wisc.edu/condor/license.html#condor",
-        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
-      ]
-    },
-    {
-      "name": "copyleft-next 0.3.0",
-      "licenseId": "copyleft-next-0.3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
-      ]
-    },
-    {
-      "name": "copyleft-next 0.3.1",
-      "licenseId": "copyleft-next-0.3.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
-      ]
-    },
-    {
-      "name": "Cornell Lossless JPEG License",
-      "licenseId": "Cornell-Lossless-JPEG",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_lossless_jpeg.cpp#16",
-        "https://www.mssl.ucl.ac.uk/~mcrw/src/20050920/proto.h",
-        "https://gitlab.freedesktop.org/libopenraw/libopenraw/blob/master/lib/ljpegdecompressor.cpp#L32"
-      ]
-    },
-    {
-      "name": "Common Public Attribution License 1.0",
-      "licenseId": "CPAL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/CPAL-1.0"
-      ]
-    },
-    {
-      "name": "Common Public License 1.0",
-      "licenseId": "CPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/CPL-1.0"
-      ]
-    },
-    {
-      "name": "Code Project Open License 1.02",
-      "licenseId": "CPOL-1.02",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.codeproject.com/info/cpol10.aspx"
-      ]
-    },
-    {
-      "name": "Cronyx License",
-      "licenseId": "Cronyx",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/font/alias/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/font/cronyx-cyrillic/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/font/misc-cyrillic/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/font/screen-cyrillic/-/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "Crossword License",
-      "licenseId": "Crossword",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Crossword"
-      ]
-    },
-    {
-      "name": "CrystalStacker License",
-      "licenseId": "CrystalStacker",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd=Licensing/CrystalStacker"
-      ]
-    },
-    {
-      "name": "CUA Office Public License v1.0",
-      "licenseId": "CUA-OPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/CUA-OPL-1.0"
-      ]
-    },
-    {
-      "name": "Cube License",
-      "licenseId": "Cube",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Cube"
-      ]
-    },
-    {
-      "name": "curl License",
-      "licenseId": "curl",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "Common Vulnerability Enumeration ToU License",
-      "licenseId": "cve-tou",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.cve.org/Legal/TermsOfUse"
-      ]
-    },
-    {
-      "name": "Deutsche Freie Software Lizenz",
-      "licenseId": "D-FSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.dipp.nrw.de/d-fsl/lizenzen/",
-        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/de/D-FSL-1_0_de.txt",
-        "http://www.dipp.nrw.de/d-fsl/index_html/lizenzen/en/D-FSL-1_0_en.txt",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/deutsche-freie-software-lizenz",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/german-free-software-license",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_de.txt/at_download/file",
-        "https://www.hbz-nrw.de/produkte/open-access/lizenzen/dfsl/D-FSL-1_0_en.txt/at_download/file"
-      ]
-    },
-    {
-      "name": "DEC 3-Clause License",
-      "licenseId": "DEC-3-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L239"
-      ]
-    },
-    {
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ]
-    },
-    {
-      "name": "Data licence Germany – attribution – version 2.0",
-      "licenseId": "DL-DE-BY-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.govdata.de/dl-de/by-2-0"
-      ]
-    },
-    {
-      "name": "Data licence Germany – zero – version 2.0",
-      "licenseId": "DL-DE-ZERO-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.govdata.de/dl-de/zero-2-0"
-      ]
-    },
-    {
-      "name": "DOC License",
-      "licenseId": "DOC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
-        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
-      ]
-    },
-    {
-      "name": "DocBook Schema License",
-      "licenseId": "DocBook-Schema",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc"
-      ]
-    },
-    {
-      "name": "DocBook Stylesheet License",
-      "licenseId": "DocBook-Stylesheet",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
-      ]
-    },
-    {
-      "name": "DocBook XML License",
-      "licenseId": "DocBook-XML",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/COPYING#L27"
-      ]
-    },
-    {
-      "name": "Dotseqn License",
-      "licenseId": "Dotseqn",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
-      ]
-    },
-    {
-      "name": "Detection Rule License 1.0",
-      "licenseId": "DRL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
-      ]
-    },
-    {
-      "name": "Detection Rule License 1.1",
-      "licenseId": "DRL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/SigmaHQ/Detection-Rule-License/blob/6ec7fbde6101d101b5b5d1fcb8f9b69fbc76c04a/LICENSE.Detection.Rules.md"
-      ]
-    },
-    {
-      "name": "DSDP License",
-      "licenseId": "DSDP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/DSDP"
-      ]
-    },
-    {
-      "name": "David M. Gay dtoa License",
-      "licenseId": "dtoa",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/SWI-Prolog/swipl-devel/blob/master/src/os/dtoa.c",
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/stdlib/mprec.h;hb=HEAD"
-      ]
-    },
-    {
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
-      ]
-    },
-    {
-      "name": "Educational Community License v1.0",
-      "licenseId": "ECL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/ECL-1.0"
-      ]
-    },
-    {
-      "name": "Educational Community License v2.0",
-      "licenseId": "ECL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/ECL-2.0"
-      ]
-    },
-    {
-      "name": "eCos license version 2.0",
-      "licenseId": "eCos-2.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/ecos-license.html"
-      ]
-    },
-    {
-      "name": "Eiffel Forum License v1.0",
-      "licenseId": "EFL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/forum.txt",
-        "https://opensource.org/licenses/EFL-1.0"
-      ]
-    },
-    {
-      "name": "Eiffel Forum License v2.0",
-      "licenseId": "EFL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "https://opensource.org/licenses/EFL-2.0"
-      ]
-    },
-    {
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
-      ]
-    },
-    {
-      "name": "Elastic License 2.0",
-      "licenseId": "Elastic-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.elastic.co/licensing/elastic-license",
-        "https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt"
-      ]
-    },
-    {
-      "name": "Entessa Public License v1.0",
-      "licenseId": "Entessa",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Entessa"
-      ]
-    },
-    {
-      "name": "EPICS Open License",
-      "licenseId": "EPICS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://epics.anl.gov/license/open.php"
-      ]
-    },
-    {
-      "name": "Eclipse Public License 1.0",
-      "licenseId": "EPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.eclipse.org/legal/epl-v10.html",
-        "https://opensource.org/licenses/EPL-1.0"
-      ]
-    },
-    {
-      "name": "Eclipse Public License 2.0",
-      "licenseId": "EPL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0"
-      ]
-    },
-    {
-      "name": "Erlang Public License v1.1",
-      "licenseId": "ErlPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.erlang.org/EPLICENSE"
-      ]
-    },
-    {
-      "name": "Etalab Open License 2.0",
-      "licenseId": "etalab-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
-        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
-      ]
-    },
-    {
-      "name": "EU DataGrid Software License",
-      "licenseId": "EUDatagrid",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "https://opensource.org/licenses/EUDatagrid"
-      ]
-    },
-    {
-      "name": "European Union Public License 1.0",
-      "licenseId": "EUPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://ec.europa.eu/idabc/en/document/7330.html",
-        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id=31096"
-      ]
-    },
-    {
-      "name": "European Union Public License 1.1",
-      "licenseId": "EUPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "https://opensource.org/licenses/EUPL-1.1"
-      ]
-    },
-    {
-      "name": "European Union Public License 1.2",
-      "licenseId": "EUPL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://joinup.ec.europa.eu/page/eupl-text-11-12",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
-        "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
-        "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32017D0863",
-        "https://opensource.org/licenses/EUPL-1.2"
-      ]
-    },
-    {
-      "name": "Eurosym License",
-      "licenseId": "Eurosym",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Eurosym"
-      ]
-    },
-    {
-      "name": "Fair License",
-      "licenseId": "Fair",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://web.archive.org/web/20150926120323/http://fairlicense.org/",
-        "https://opensource.org/licenses/Fair"
-      ]
-    },
-    {
-      "name": "Fuzzy Bitmap License",
-      "licenseId": "FBM",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/SWI-Prolog/packages-xpce/blob/161a40cd82004f731ba48024f9d30af388a7edf5/src/img/gifwrite.c#L21-L26"
-      ]
-    },
-    {
-      "name": "Fraunhofer FDK AAC Codec Library",
-      "licenseId": "FDK-AAC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FDK-AAC",
-        "https://directory.fsf.org/wiki/License:Fdk"
-      ]
-    },
-    {
-      "name": "Ferguson Twofish License",
-      "licenseId": "Ferguson-Twofish",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/wernerd/ZRTPCPP/blob/6b3cd8e6783642292bad0c21e3e5e5ce45ff3e03/cryptcommon/twofish.c#L113C3-L127"
-      ]
-    },
-    {
-      "name": "Frameworx Open License 1.0",
-      "licenseId": "Frameworx-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Frameworx-1.0"
-      ]
-    },
-    {
-      "name": "FreeBSD Documentation License",
-      "licenseId": "FreeBSD-DOC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.freebsd.org/copyright/freebsd-doc-license/"
-      ]
-    },
-    {
-      "name": "FreeImage Public License v1.0",
-      "licenseId": "FreeImage",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://freeimage.sourceforge.net/freeimage-license.txt"
-      ]
-    },
-    {
-      "name": "FSF All Permissive License",
-      "licenseId": "FSFAP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
-      ]
-    },
-    {
-      "name": "FSF All Permissive License (without Warranty)",
-      "licenseId": "FSFAP-no-warranty-disclaimer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.savannah.gnu.org/cgit/wget.git/tree/util/trunc.c?h=v1.21.3&id=40747a11e44ced5a8ac628a41f879ced3e2ebce9#n6"
-      ]
-    },
-    {
-      "name": "FSF Unlimited License",
-      "licenseId": "FSFUL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
-      ]
-    },
-    {
-      "name": "FSF Unlimited License (with License Retention)",
-      "licenseId": "FSFULLR",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
-      ]
-    },
-    {
-      "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
-      "licenseId": "FSFULLRWD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://lists.gnu.org/archive/html/autoconf/2012-04/msg00061.html"
-      ]
-    },
-    {
-      "name": "Freetype Project License",
-      "licenseId": "FTL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://freetype.fis.uniroma2.it/FTL.TXT",
-        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT",
-        "http://gitlab.freedesktop.org/freetype/freetype/-/raw/master/docs/FTL.TXT"
-      ]
-    },
-    {
-      "name": "Furuseth License",
-      "licenseId": "Furuseth",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT?ref_type=heads#L39-51"
-      ]
-    },
-    {
-      "name": "fwlw License",
-      "licenseId": "fwlw",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/fwlw/README"
-      ]
-    },
-    {
-      "name": "Gnome GCR Documentation License",
-      "licenseId": "GCR-docs",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/GNOME/gcr/blob/master/docs/COPYING"
-      ]
-    },
-    {
-      "name": "GD License",
-      "licenseId": "GD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
-      ]
-    },
-    {
-      "name": "Generic XTS License",
-      "licenseId": "generic-xts",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/mhogomchungu/zuluCrypt/blob/master/external_libraries/tcplay/generic_xts.c"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1",
-      "licenseId": "GFDL-1.1",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 only - invariants",
-      "licenseId": "GFDL-1.1-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 or later - invariants",
-      "licenseId": "GFDL-1.1-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 only - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 or later - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 only",
-      "licenseId": "GFDL-1.1-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.1 or later",
-      "licenseId": "GFDL-1.1-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2",
-      "licenseId": "GFDL-1.2",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 only - invariants",
-      "licenseId": "GFDL-1.2-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 or later - invariants",
-      "licenseId": "GFDL-1.2-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 only - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 or later - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 only",
-      "licenseId": "GFDL-1.2-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.2 or later",
-      "licenseId": "GFDL-1.2-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3",
-      "licenseId": "GFDL-1.3",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 only - invariants",
-      "licenseId": "GFDL-1.3-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 or later - invariants",
-      "licenseId": "GFDL-1.3-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 only - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 or later - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 only",
-      "licenseId": "GFDL-1.3-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "GNU Free Documentation License v1.3 or later",
-      "licenseId": "GFDL-1.3-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ]
-    },
-    {
-      "name": "Giftware License",
-      "licenseId": "Giftware",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
-      ]
-    },
-    {
-      "name": "GL2PS License",
-      "licenseId": "GL2PS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
-      ]
-    },
-    {
-      "name": "3dfx Glide License",
-      "licenseId": "Glide",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
-      ]
-    },
-    {
-      "name": "Glulxe License",
-      "licenseId": "Glulxe",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Glulxe"
-      ]
-    },
-    {
-      "name": "Good Luck With That Public License",
-      "licenseId": "GLWTPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
-      ]
-    },
-    {
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
-      ]
-    },
-    {
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
-        "https://opensource.org/licenses/GPL-2.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 w/Autoconf exception",
-      "licenseId": "GPL-2.0-with-autoconf-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 w/Bison exception",
-      "licenseId": "GPL-2.0-with-bison-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 w/Classpath exception",
-      "licenseId": "GPL-2.0-with-classpath-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/software/classpath/license.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 w/Font exception",
-      "licenseId": "GPL-2.0-with-font-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ]
-    },
-    {
-      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-2.0-with-GCC-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 w/Autoconf exception",
-      "licenseId": "GPL-3.0-with-autoconf-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ]
-    },
-    {
-      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-3.0-with-GCC-exception",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ]
-    },
-    {
-      "name": "Graphics Gems License",
-      "licenseId": "Graphics-Gems",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/erich666/GraphicsGems/blob/master/LICENSE.md"
-      ]
-    },
-    {
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
-      ]
-    },
-    {
-      "name": "gtkbook License",
-      "licenseId": "gtkbook",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/slogan621/gtkbook",
-        "https://github.com/oetiker/rrdtool-1.x/blob/master/src/plbasename.c#L8-L11"
-      ]
-    },
-    {
-      "name": "Gutmann License",
-      "licenseId": "Gutmann",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.cs.auckland.ac.nz/~pgut001/dumpasn1.c"
-      ]
-    },
-    {
-      "name": "Haskell Language Report License",
-      "licenseId": "HaskellReport",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
-      ]
-    },
-    {
-      "name": "hdparm License",
-      "licenseId": "hdparm",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Distrotech/hdparm/blob/4517550db29a91420fb2b020349523b1b4512df2/LICENSE.TXT"
-      ]
-    },
-    {
-      "name": "HIDAPI License",
-      "licenseId": "HIDAPI",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt"
-      ]
-    },
-    {
-      "name": "Hippocratic License 2.1",
-      "licenseId": "Hippocratic-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://firstdonoharm.dev/version/2/1/license.html",
-        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
-      ]
-    },
-    {
-      "name": "Hewlett-Packard 1986 License",
-      "licenseId": "HP-1986",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/hppa/memchr.S;h=1cca3e5e8867aa4bffef1f75a5c1bba25c0c441e;hb=HEAD#l2"
-      ]
-    },
-    {
-      "name": "Hewlett-Packard 1989 License",
-      "licenseId": "HP-1989",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/bleargh45/Data-UUID/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/HPND",
-        "http://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2002-November/006304.html"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - DEC variant",
-      "licenseId": "HPND-DEC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/blob/master/COPYING?ref_type=heads#L69"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - documentation variant",
-      "licenseId": "HPND-doc",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type=heads#L185-197",
-        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type=heads#L70-77"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
-      "licenseId": "HPND-doc-sell",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type=heads#L108-117",
-        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type=heads#L153-162"
-      ]
-    },
-    {
-      "name": "HPND with US Government export control warning",
-      "licenseId": "HPND-export-US",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.kermitproject.org/ck90.html#source"
-      ]
-    },
-    {
-      "name": "HPND with US Government export control warning and acknowledgment",
-      "licenseId": "HPND-export-US-acknowledgement",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
-      ]
-    },
-    {
-      "name": "HPND with US Government export control warning and modification rqmt",
-      "licenseId": "HPND-export-US-modify",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L1157-L1182",
-        "https://github.com/pythongssapi/k5test/blob/v0.10.3/K5TEST-LICENSE.txt"
-      ]
-    },
-    {
-      "name": "HPND with US Government export control and 2 disclaimers",
-      "licenseId": "HPND-export2-US",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L111-L133",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
-      "licenseId": "HPND-Fenneberg-Livingston",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/FreeRADIUS/freeradius-client/blob/master/COPYRIGHT#L32",
-        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L34"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
-      "licenseId": "HPND-INRIA-IMAG",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ppp-project/ppp/blob/master/pppd/ipv6cp.c#L75-L83"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Intel variant",
-      "licenseId": "HPND-Intel",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/i960/memcpy.S;hb=HEAD"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
-      "licenseId": "HPND-Kevlin-Henney",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/mruby/mruby/blob/83d12f8d52522cdb7c8cc46fad34821359f453e6/mrbgems/mruby-dir/src/Win/dirent.c#L127-L140"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
-      "licenseId": "HPND-Markus-Kuhn",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c",
-        "https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=readline/readline/support/wcwidth.c;h=0f5ec995796f4813abbcf4972aec0378ab74722a;hb=HEAD#l55"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - merchantability variant",
-      "licenseId": "HPND-merchantability-variant",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/misc/fini.c;hb=HEAD"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
-      "licenseId": "HPND-MIT-disclaimer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/release/NLNETLABS/Net-DNS-SEC-1.22/source/LICENSE"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Netrek variant",
-      "licenseId": "HPND-Netrek",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": []
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
-      "licenseId": "HPND-Pbmplus",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/netpbm.c#l8"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
-      "licenseId": "HPND-sell-MIT-disclaimer-xserver",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type=heads#L1781"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
-      "licenseId": "HPND-sell-regexpr",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.com/bacula-org/bacula/-/blob/Branch-11.0/bacula/LICENSE-FOSS?ref_type=heads#L245"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - sell variant",
-      "licenseId": "HPND-sell-variant",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19",
-        "https://github.com/kfish/xsel/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "HPND sell variant with MIT disclaimer",
-      "licenseId": "HPND-sell-variant-MIT-disclaimer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/README"
-      ]
-    },
-    {
-      "name": "HPND sell variant with MIT disclaimer - reverse",
-      "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/dynlist.c"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - University of California variant",
-      "licenseId": "HPND-UC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://core.tcl-lang.org/tk/file?name=compat/unistd.h"
-      ]
-    },
-    {
-      "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
-      "licenseId": "HPND-UC-export-US",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/RTimothyEdwards/magic/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "HTML Tidy License",
-      "licenseId": "HTMLTIDY",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
-      ]
-    },
-    {
-      "name": "IBM PowerPC Initialization and Boot Software",
-      "licenseId": "IBM-pibs",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d"
-      ]
-    },
-    {
-      "name": "ICU License",
-      "licenseId": "ICU",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
-      ]
-    },
-    {
-      "name": "IEC    Code Components End-user licence agreement",
-      "licenseId": "IEC-Code-Components-EULA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.iec.ch/webstore/custserv/pdf/CC-EULA.pdf",
-        "https://www.iec.ch/CCv1",
-        "https://www.iec.ch/copyright"
-      ]
-    },
-    {
-      "name": "Independent JPEG Group License",
-      "licenseId": "IJG",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev=1.2"
-      ]
-    },
-    {
-      "name": "Independent JPEG Group License - short",
-      "licenseId": "IJG-short",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/ljpg/"
-      ]
-    },
-    {
-      "name": "ImageMagick License",
-      "licenseId": "ImageMagick",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.imagemagick.org/script/license.php"
-      ]
-    },
-    {
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
-      ]
-    },
-    {
-      "name": "Imlib2 License",
-      "licenseId": "Imlib2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
-        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
-      ]
-    },
-    {
-      "name": "Info-ZIP License",
-      "licenseId": "Info-ZIP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.info-zip.org/license.html"
-      ]
-    },
-    {
-      "name": "Inner Net License v2.0",
-      "licenseId": "Inner-Net-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Inner_Net_License",
-        "https://sourceware.org/git/?p=glibc.git;a=blob;f=LICENSES;h=530893b1dc9ea00755603c68fb36bd4fc38a7be8;hb=HEAD#l207"
-      ]
-    },
-    {
-      "name": "Inno Setup License",
-      "licenseId": "InnoSetup",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/jrsoftware/issrc/blob/HEAD/license.txt"
-      ]
-    },
-    {
-      "name": "Intel Open Source License",
-      "licenseId": "Intel",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/Intel"
-      ]
-    },
-    {
-      "name": "Intel ACPI Software License Agreement",
-      "licenseId": "Intel-ACPI",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
-      ]
-    },
-    {
-      "name": "Interbase Public License v1.0",
-      "licenseId": "Interbase-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
-      ]
-    },
-    {
-      "name": "IPA Font License",
-      "licenseId": "IPA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/IPA"
-      ]
-    },
-    {
-      "name": "IBM Public License v1.0",
-      "licenseId": "IPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/IPL-1.0"
-      ]
-    },
-    {
-      "name": "ISC License",
-      "licenseId": "ISC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.isc.org/licenses/",
-        "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "https://opensource.org/licenses/ISC"
-      ]
-    },
-    {
-      "name": "ISC Veillard variant",
-      "licenseId": "ISC-Veillard",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c",
-        "https://github.com/GNOME/libxml2/blob/master/dict.c",
-        "https://sourceforge.net/p/ctrio/git/ci/master/tree/README"
-      ]
-    },
-    {
-      "name": "Jam License",
-      "licenseId": "Jam",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.boost.org/doc/libs/1_35_0/doc/html/jam.html",
-        "https://web.archive.org/web/20160330173339/https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/README"
-      ]
-    },
-    {
-      "name": "JasPer License",
-      "licenseId": "JasPer-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
-      ]
-    },
-    {
-      "name": "JPL Image Use Policy",
-      "licenseId": "JPL-image",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.jpl.nasa.gov/jpl-image-use-policy"
-      ]
-    },
-    {
-      "name": "Japan Network Information Center License",
-      "licenseId": "JPNIC",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
-      ]
-    },
-    {
-      "name": "JSON License",
-      "licenseId": "JSON",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.json.org/license.html"
-      ]
-    },
-    {
-      "name": "Kastrup License",
-      "licenseId": "Kastrup",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/kastrup/binhex.dtx"
-      ]
-    },
-    {
-      "name": "Kazlib License",
-      "licenseId": "Kazlib",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/kazlib.git/tree/except.c?id=0062df360c2d17d57f6af19b0e444c51feb99036"
-      ]
-    },
-    {
-      "name": "Knuth CTAN License",
-      "licenseId": "Knuth-CTAN",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://ctan.org/license/knuth"
-      ]
-    },
-    {
-      "name": "Licence Art Libre 1.2",
-      "licenseId": "LAL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://artlibre.org/licence/lal/licence-art-libre-12/"
-      ]
-    },
-    {
-      "name": "Licence Art Libre 1.3",
-      "licenseId": "LAL-1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://artlibre.org/"
-      ]
-    },
-    {
-      "name": "Latex2e License",
-      "licenseId": "Latex2e",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Latex2e"
-      ]
-    },
-    {
-      "name": "Latex2e with translated notice permission",
-      "licenseId": "Latex2e-translated-notice",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id=a74c6b4ee49397cf330b333da1042bffa60ed14f#n74"
-      ]
-    },
-    {
-      "name": "Leptonica License",
-      "licenseId": "Leptonica",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Leptonica"
-      ]
-    },
-    {
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0-only",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ]
-    },
-    {
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0-or-later",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ]
-    },
-    {
-      "name": "Lesser General Public License For Linguistic Resources",
-      "licenseId": "LGPLLR",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
-      ]
-    },
-    {
-      "name": "libpng License",
-      "licenseId": "Libpng",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ]
-    },
-    {
-      "name": "PNG Reference Library version 2",
-      "licenseId": "libpng-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ]
-    },
-    {
-      "name": "libselinux public domain notice",
-      "licenseId": "libselinux-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
-      ]
-    },
-    {
-      "name": "libtiff License",
-      "licenseId": "libtiff",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
-      ]
-    },
-    {
-      "name": "libutil David Nugent License",
-      "licenseId": "libutil-David-Nugent",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://web.mit.edu/freebsd/head/lib/libutil/login_ok.3",
-        "https://cgit.freedesktop.org/libbsd/tree/man/setproctitle.3bsd"
-      ]
-    },
-    {
-      "name": "Licence Libre du Québec – Permissive version 1.1",
-      "licenseId": "LiLiQ-P-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
-      ]
-    },
-    {
-      "name": "Licence Libre du Québec – Réciprocité version 1.1",
-      "licenseId": "LiLiQ-R-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
-      ]
-    },
-    {
-      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
-      "licenseId": "LiLiQ-Rplus-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
-      ]
-    },
-    {
-      "name": "Linux man-pages - 1 paragraph",
-      "licenseId": "Linux-man-pages-1-para",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/getcpu.2#n4"
-      ]
-    },
-    {
-      "name": "Linux man-pages Copyleft",
-      "licenseId": "Linux-man-pages-copyleft",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.kernel.org/doc/man-pages/licenses.html"
-      ]
-    },
-    {
-      "name": "Linux man-pages Copyleft - 2 paragraphs",
-      "licenseId": "Linux-man-pages-copyleft-2-para",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/move_pages.2#n5",
-        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/migrate_pages.2#n8"
-      ]
-    },
-    {
-      "name": "Linux man-pages Copyleft Variant",
-      "licenseId": "Linux-man-pages-copyleft-var",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/set_mempolicy.2#n5"
-      ]
-    },
-    {
-      "name": "Linux Kernel Variant of OpenIB.org license",
-      "licenseId": "Linux-OpenIB",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
-      ]
-    },
-    {
-      "name": "Common Lisp LOOP License",
-      "licenseId": "LOOP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.com/embeddable-common-lisp/ecl/-/blob/develop/src/lsp/loop.lsp",
-        "http://git.savannah.gnu.org/cgit/gcl.git/tree/gcl/lsp/gcl_loop.lsp?h=Version_2_6_13pre",
-        "https://sourceforge.net/p/sbcl/sbcl/ci/master/tree/src/code/loop.lisp",
-        "https://github.com/cl-adams/adams/blob/master/LICENSE.md",
-        "https://github.com/blakemcbride/eclipse-lisp/blob/master/lisp/loop.lisp",
-        "https://gitlab.common-lisp.net/cmucl/cmucl/-/blob/master/src/code/loop.lisp"
-      ]
-    },
-    {
-      "name": "LPD Documentation License",
-      "licenseId": "LPD-document",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md",
-        "https://www.ietf.org/rfc/rfc1952.txt"
-      ]
-    },
-    {
-      "name": "Lucent Public License Version 1.0",
-      "licenseId": "LPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/LPL-1.0"
-      ]
-    },
-    {
-      "name": "Lucent Public License v1.02",
-      "licenseId": "LPL-1.02",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://plan9.bell-labs.com/plan9/license.html",
-        "https://opensource.org/licenses/LPL-1.02"
-      ]
-    },
-    {
-      "name": "LaTeX Project Public License v1.0",
-      "licenseId": "LPPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-0.txt"
-      ]
-    },
-    {
-      "name": "LaTeX Project Public License v1.1",
-      "licenseId": "LPPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-1.txt"
-      ]
-    },
-    {
-      "name": "LaTeX Project Public License v1.2",
-      "licenseId": "LPPL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-2.txt"
-      ]
-    },
-    {
-      "name": "LaTeX Project Public License v1.3a",
-      "licenseId": "LPPL-1.3a",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
-      ]
-    },
-    {
-      "name": "LaTeX Project Public License v1.3c",
-      "licenseId": "LPPL-1.3c",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "https://opensource.org/licenses/LPPL-1.3c"
-      ]
-    },
-    {
-      "name": "lsof License",
-      "licenseId": "lsof",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/lsof-org/lsof/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "Lucida Bitmap Fonts License",
-      "licenseId": "Lucida-Bitmap-Fonts",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/font/bh-100dpi/-/blob/master/COPYING?ref_type=heads"
-      ]
-    },
-    {
-      "name": "LZMA SDK License (versions 9.11 to 9.20)",
-      "licenseId": "LZMA-SDK-9.11-to-9.20",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.7-zip.org/sdk.html",
-        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
-      ]
-    },
-    {
-      "name": "LZMA SDK License (versions 9.22 and beyond)",
-      "licenseId": "LZMA-SDK-9.22",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.7-zip.org/sdk.html",
-        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
-      ]
-    },
-    {
-      "name": "Mackerras 3-Clause License",
-      "licenseId": "Mackerras-3-Clause",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ppp-project/ppp/blob/master/pppd/chap_ms.c#L6-L28"
-      ]
-    },
-    {
-      "name": "Mackerras 3-Clause - acknowledgment variant",
-      "licenseId": "Mackerras-3-Clause-acknowledgment",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ppp-project/ppp/blob/master/pppd/auth.c#L6-L28"
-      ]
-    },
-    {
-      "name": "magaz License",
-      "licenseId": "magaz",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/magaz/magaz.tex"
-      ]
-    },
-    {
-      "name": "mailprio License",
-      "licenseId": "mailprio",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fossies.org/linux/sendmail/contrib/mailprio"
-      ]
-    },
-    {
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
-      ]
-    },
-    {
-      "name": "Martin Birgmeier License",
-      "licenseId": "Martin-Birgmeier",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Perl/perl5/blob/blead/util.c#L6136"
-      ]
-    },
-    {
-      "name": "McPhee Slideshow License",
-      "licenseId": "McPhee-slideshow",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://mirror.las.iastate.edu/tex-archive/graphics/metapost/contrib/macros/slideshow/slideshow.mp"
-      ]
-    },
-    {
-      "name": "metamail License",
-      "licenseId": "metamail",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Dual-Life/mime-base64/blob/master/Base64.xs#L12"
-      ]
-    },
-    {
-      "name": "Minpack License",
-      "licenseId": "Minpack",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.netlib.org/minpack/disclaimer",
-        "https://gitlab.com/libeigen/eigen/-/blob/master/COPYING.MINPACK"
-      ]
-    },
-    {
-      "name": "MIPS License",
-      "licenseId": "MIPS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
-      ]
-    },
-    {
-      "name": "The MirOS Licence",
-      "licenseId": "MirOS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/MirOS"
-      ]
-    },
-    {
-      "name": "MIT License",
-      "licenseId": "MIT",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/license/mit/"
-      ]
-    },
-    {
-      "name": "MIT No Attribution",
-      "licenseId": "MIT-0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/aws/mit-0",
-        "https://romanrm.net/mit-zero",
-        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
-      ]
-    },
-    {
-      "name": "Enlightenment License (e16)",
-      "licenseId": "MIT-advertising",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
-      ]
-    },
-    {
-      "name": "MIT Click License",
-      "licenseId": "MIT-Click",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/kohler/t1utils/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "CMU License",
-      "licenseId": "MIT-CMU",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style",
-        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
-      ]
-    },
-    {
-      "name": "enna License",
-      "licenseId": "MIT-enna",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
-      ]
-    },
-    {
-      "name": "feh License",
-      "licenseId": "MIT-feh",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
-      ]
-    },
-    {
-      "name": "MIT Festival Variant",
-      "licenseId": "MIT-Festival",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/festvox/flite/blob/master/COPYING",
-        "https://github.com/festvox/speech_tools/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "MIT Khronos - old variant",
-      "licenseId": "MIT-Khronos-old",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSES/LicenseRef-KhronosFreeUse.txt"
-      ]
-    },
-    {
-      "name": "MIT License Modern Variant",
-      "licenseId": "MIT-Modern-Variant",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
-        "https://ptolemy.berkeley.edu/copyright.htm",
-        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
-      ]
-    },
-    {
-      "name": "MIT Open Group variant",
-      "licenseId": "MIT-open-group",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "MIT testregex Variant",
-      "licenseId": "MIT-testregex",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/dotnet/runtime/blob/55e1ac7c07df62c4108d4acedf78f77574470ce5/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/AttRegexTests.cs#L12-L28"
-      ]
-    },
-    {
-      "name": "MIT Tom Wu Variant",
-      "licenseId": "MIT-Wu",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/chromium/octane/blob/master/crypto.js"
-      ]
-    },
-    {
-      "name": "MIT +no-false-attribs license",
-      "licenseId": "MITNFA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MITNFA"
-      ]
-    },
-    {
-      "name": "MMIXware License",
-      "licenseId": "MMIXware",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.lrz.de/mmix/mmixware/-/blob/master/boilerplate.w"
-      ]
-    },
-    {
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Motosoto"
-      ]
-    },
-    {
-      "name": "MPEG Software Simulation",
-      "licenseId": "MPEG-SSG",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/ppm/ppmtompeg/jrevdct.c#l1189"
-      ]
-    },
-    {
-      "name": "mpi Permissive License",
-      "licenseId": "mpi-permissive",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sources.debian.org/src/openmpi/4.1.0-10/ompi/debuggers/msgq_interface.h/?hl=19#L19"
-      ]
-    },
-    {
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ]
-    },
-    {
-      "name": "Mozilla Public License 1.0",
-      "licenseId": "MPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "https://opensource.org/licenses/MPL-1.0"
-      ]
-    },
-    {
-      "name": "Mozilla Public License 1.1",
-      "licenseId": "MPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "https://opensource.org/licenses/MPL-1.1"
-      ]
-    },
-    {
-      "name": "Mozilla Public License 2.0",
-      "licenseId": "MPL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.mozilla.org/MPL/2.0/",
-        "https://opensource.org/licenses/MPL-2.0"
-      ]
-    },
-    {
-      "name": "Mozilla Public License 2.0 (no copyleft exception)",
-      "licenseId": "MPL-2.0-no-copyleft-exception",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.mozilla.org/MPL/2.0/",
-        "https://opensource.org/licenses/MPL-2.0"
-      ]
-    },
-    {
-      "name": "mplus Font License",
-      "licenseId": "mplus",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:Mplus?rd=Licensing/mplus"
-      ]
-    },
-    {
-      "name": "Microsoft Limited Public License",
-      "licenseId": "MS-LPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.openhub.net/licenses/mslpl",
-        "https://github.com/gabegundy/atlserver/blob/master/License.txt",
-        "https://en.wikipedia.org/wiki/Shared_Source_Initiative#Microsoft_Limited_Public_License_(Ms-LPL)"
-      ]
-    },
-    {
-      "name": "Microsoft Public License",
-      "licenseId": "MS-PL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-PL"
-      ]
-    },
-    {
-      "name": "Microsoft Reciprocal License",
-      "licenseId": "MS-RL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-RL"
-      ]
-    },
-    {
-      "name": "Matrix Template Library License",
-      "licenseId": "MTLL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
-      ]
-    },
-    {
-      "name": "Mulan Permissive Software License, Version 1",
-      "licenseId": "MulanPSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://license.coscl.org.cn/MulanPSL/",
-        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
-      ]
-    },
-    {
-      "name": "Mulan Permissive Software License, Version 2",
-      "licenseId": "MulanPSL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://license.coscl.org.cn/MulanPSL2"
-      ]
-    },
-    {
-      "name": "Multics License",
-      "licenseId": "Multics",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Multics"
-      ]
-    },
-    {
-      "name": "Mup License",
-      "licenseId": "Mup",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Mup"
-      ]
-    },
-    {
-      "name": "Nara Institute of Science and Technology License (2003)",
-      "licenseId": "NAIST-2003",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
-        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
-      ]
-    },
-    {
-      "name": "NASA Open Source Agreement 1.3",
-      "licenseId": "NASA-1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://ti.arc.nasa.gov/opensource/nosa/",
-        "https://opensource.org/licenses/NASA-1.3"
-      ]
-    },
-    {
-      "name": "Naumen Public License",
-      "licenseId": "Naumen",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Naumen"
-      ]
-    },
-    {
-      "name": "Net Boolean Public License v1",
-      "licenseId": "NBPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
-      ]
-    },
-    {
-      "name": "NCBI Public Domain Notice",
-      "licenseId": "NCBI-PD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ncbi/sra-tools/blob/e8e5b6af4edc460156ad9ce5902d0779cffbf685/LICENSE",
-        "https://github.com/ncbi/datasets/blob/0ea4cd16b61e5b799d9cc55aecfa016d6c9bd2bf/LICENSE.md",
-        "https://github.com/ncbi/gprobe/blob/de64d30fee8b4c4013094d7d3139ea89b5dd1ace/LICENSE",
-        "https://github.com/ncbi/egapx/blob/08930b9dec0c69b2d1a05e5153c7b95ef0a3eb0f/LICENSE",
-        "https://github.com/ncbi/datasets/blob/master/LICENSE.md"
-      ]
-    },
-    {
-      "name": "Non-Commercial Government Licence",
-      "licenseId": "NCGL-UK-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/"
-      ]
-    },
-    {
-      "name": "NCL Source Code License",
-      "licenseId": "NCL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/modules/module-filter-chain/pffft.c?ref_type=heads#L1-52"
-      ]
-    },
-    {
-      "name": "University of Illinois/NCSA Open Source License",
-      "licenseId": "NCSA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://otm.illinois.edu/uiuc_openSource",
-        "https://opensource.org/licenses/NCSA"
-      ]
-    },
-    {
-      "name": "Net-SNMP License",
-      "licenseId": "Net-SNMP",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://net-snmp.sourceforge.net/about/license.html"
-      ]
-    },
-    {
-      "name": "NetCDF license",
-      "licenseId": "NetCDF",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
-      ]
-    },
-    {
-      "name": "Newsletr License",
-      "licenseId": "Newsletr",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Newsletr"
-      ]
-    },
-    {
-      "name": "Nethack General Public License",
-      "licenseId": "NGPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/NGPL"
-      ]
-    },
-    {
-      "name": "NICTA Public Software License, Version 1.0",
-      "licenseId": "NICTA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.apple.com/source/mDNSResponder/mDNSResponder-320.10/mDNSPosix/nss_ReadMe.txt"
-      ]
-    },
-    {
-      "name": "NIST Public Domain Notice",
-      "licenseId": "NIST-PD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
-        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
-      ]
-    },
-    {
-      "name": "NIST Public Domain Notice with license fallback",
-      "licenseId": "NIST-PD-fallback",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
-        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
-      ]
-    },
-    {
-      "name": "NIST Software License",
-      "licenseId": "NIST-Software",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/open-quantum-safe/liboqs/blob/40b01fdbb270f8614fde30e65d30e9da18c02393/src/common/rand/rand_nist.c#L1-L15"
-      ]
-    },
-    {
-      "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
-      "licenseId": "NLOD-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/1.0"
-      ]
-    },
-    {
-      "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
-      "licenseId": "NLOD-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/2.0"
-      ]
-    },
-    {
-      "name": "No Limit Public License",
-      "licenseId": "NLPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/NLPL"
-      ]
-    },
-    {
-      "name": "Nokia Open Source License",
-      "licenseId": "Nokia",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/nokia"
-      ]
-    },
-    {
-      "name": "Netizen Open Source License",
-      "licenseId": "NOSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
-      ]
-    },
-    {
-      "name": "Noweb License",
-      "licenseId": "Noweb",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Noweb"
-      ]
-    },
-    {
-      "name": "Netscape Public License v1.0",
-      "licenseId": "NPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.0/"
-      ]
-    },
-    {
-      "name": "Netscape Public License v1.1",
-      "licenseId": "NPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.1/"
-      ]
-    },
-    {
-      "name": "Non-Profit Open Software License 3.0",
-      "licenseId": "NPOSL-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/NOSL3.0"
-      ]
-    },
-    {
-      "name": "NRL License",
-      "licenseId": "NRL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://web.mit.edu/network/isakmp/nrllicense.html"
-      ]
-    },
-    {
-      "name": "NTP License",
-      "licenseId": "NTP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/NTP"
-      ]
-    },
-    {
-      "name": "NTP No Attribution",
-      "licenseId": "NTP-0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
-      ]
-    },
-    {
-      "name": "Nunit License",
-      "licenseId": "Nunit",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Nunit"
-      ]
-    },
-    {
-      "name": "Open Use of Data Agreement v1.0",
-      "licenseId": "O-UDA-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
-        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
-      ]
-    },
-    {
-      "name": "OAR License",
-      "licenseId": "OAR",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/string/strsignal.c;hb=HEAD#l35"
-      ]
-    },
-    {
-      "name": "Open CASCADE Technology Public License",
-      "licenseId": "OCCT-PL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.opencascade.com/content/occt-public-license"
-      ]
-    },
-    {
-      "name": "OCLC Research Public License 2.0",
-      "licenseId": "OCLC-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "https://opensource.org/licenses/OCLC-2.0"
-      ]
-    },
-    {
-      "name": "Open Data Commons Open Database License v1.0",
-      "licenseId": "ODbL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/",
-        "https://opendatacommons.org/licenses/odbl/1-0/"
-      ]
-    },
-    {
-      "name": "Open Data Commons Attribution License v1.0",
-      "licenseId": "ODC-By-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opendatacommons.org/licenses/by/1.0/"
-      ]
-    },
-    {
-      "name": "OFFIS License",
-      "licenseId": "OFFIS",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/dicom/README"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.0",
-      "licenseId": "OFL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
-      "licenseId": "OFL-1.0-no-RFN",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.0 with Reserved Font Name",
-      "licenseId": "OFL-1.0-RFN",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.1",
-      "licenseId": "OFL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
-      "licenseId": "OFL-1.1-no-RFN",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
-      ]
-    },
-    {
-      "name": "SIL Open Font License 1.1 with Reserved Font Name",
-      "licenseId": "OFL-1.1-RFN",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
-      ]
-    },
-    {
-      "name": "OGC Software License, Version 1.0",
-      "licenseId": "OGC-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.ogc.org/ogc/software/1.0"
-      ]
-    },
-    {
-      "name": "Taiwan Open Government Data License, version 1.0",
-      "licenseId": "OGDL-Taiwan-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://data.gov.tw/license"
-      ]
-    },
-    {
-      "name": "Open Government Licence - Canada",
-      "licenseId": "OGL-Canada-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://open.canada.ca/en/open-government-licence-canada"
-      ]
-    },
-    {
-      "name": "Open Government Licence v1.0",
-      "licenseId": "OGL-UK-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/"
-      ]
-    },
-    {
-      "name": "Open Government Licence v2.0",
-      "licenseId": "OGL-UK-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
-      ]
-    },
-    {
-      "name": "Open Government Licence v3.0",
-      "licenseId": "OGL-UK-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-      ]
-    },
-    {
-      "name": "Open Group Test Suite License",
-      "licenseId": "OGTSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "https://opensource.org/licenses/OGTSL"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v1.1",
-      "licenseId": "OLDAP-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=806557a5ad59804ef3a44d5abfbe91d706b0791f"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v1.2",
-      "licenseId": "OLDAP-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=42b0383c50c299977b5893ee695cf4e486fb0dc7"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v1.3",
-      "licenseId": "OLDAP-1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=e5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v1.4",
-      "licenseId": "OLDAP-1.4",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=c9f95c2f3f2ffb5e0ae55fe7388af75547660941"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
-      "licenseId": "OLDAP-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.0.1",
-      "licenseId": "OLDAP-2.0.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b6d68acd14e51ca3aab4428bf26522aa74873f0e"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.1",
-      "licenseId": "OLDAP-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b0d176738e96a0d3b9f85cb51e140a86f21be715"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.2",
-      "licenseId": "OLDAP-2.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=470b0c18ec67621c85881b2733057fecf4a1acc3"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.2.1",
-      "licenseId": "OLDAP-2.2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=4bc786f34b50aa301be6f5600f58a980070f481e"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License 2.2.2",
-      "licenseId": "OLDAP-2.2.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=df2cc1e21eb7c160695f5b7cffd6296c151ba188"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.3",
-      "licenseId": "OLDAP-2.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=d32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.4",
-      "licenseId": "OLDAP-2.4",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=cd1284c4a91a8a380d904eee68d1583f989ed386"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.5",
-      "licenseId": "OLDAP-2.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=6852b9d90022e8593c98205413380536b1b5a7cf"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.6",
-      "licenseId": "OLDAP-2.6",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=1cae062821881f41b73012ba816434897abf4205"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.7",
-      "licenseId": "OLDAP-2.7",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=47c2415c1df81556eeb39be6cad458ef87c534a2"
-      ]
-    },
-    {
-      "name": "Open LDAP Public License v2.8",
-      "licenseId": "OLDAP-2.8",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.openldap.org/software/release/license.html"
-      ]
-    },
-    {
-      "name": "Open Logistics Foundation License Version 1.3",
-      "licenseId": "OLFL-1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://openlogisticsfoundation.org/licenses/",
-        "https://opensource.org/license/olfl-1-3/"
-      ]
-    },
-    {
-      "name": "Open Market License",
-      "licenseId": "OML",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
-      ]
-    },
-    {
-      "name": "OpenPBS v2.3 Software License",
-      "licenseId": "OpenPBS-2.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/adaptivecomputing/torque/blob/master/PBS_License.txt",
-        "https://www.mcs.anl.gov/research/projects/openpbs/PBS_License.txt"
-      ]
-    },
-    {
-      "name": "OpenSSL License",
-      "licenseId": "OpenSSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.openssl.org/source/license.html"
-      ]
-    },
-    {
-      "name": "OpenSSL License - standalone",
-      "licenseId": "OpenSSL-standalone",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://library.netapp.com/ecm/ecm_download_file/ECMP1196395",
-        "https://hstechdocs.helpsystems.com/manuals/globalscape/archive/cuteftp6/open_ssl_license_agreement.htm"
-      ]
-    },
-    {
-      "name": "OpenVision License",
-      "licenseId": "OpenVision",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L66-L98",
-        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html",
-        "https://fedoraproject.org/wiki/Licensing:MIT#OpenVision_Variant"
-      ]
-    },
-    {
-      "name": "Open Public License v1.0",
-      "licenseId": "OPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
-        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
-      ]
-    },
-    {
-      "name": "United    Kingdom Open Parliament Licence v3.0",
-      "licenseId": "OPL-UK-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.parliament.uk/site-information/copyright-parliament/open-parliament-licence/"
-      ]
-    },
-    {
-      "name": "Open Publication License v1.0",
-      "licenseId": "OPUBL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://opencontent.org/openpub/",
-        "https://www.debian.org/opl",
-        "https://www.ctan.org/license/opl"
-      ]
-    },
-    {
-      "name": "OSET Public License version 2.1",
-      "licenseId": "OSET-PL-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.osetfoundation.org/public-license",
-        "https://opensource.org/licenses/OPL-2.1"
-      ]
-    },
-    {
-      "name": "Open Software License 1.0",
-      "licenseId": "OSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/OSL-1.0"
-      ]
-    },
-    {
-      "name": "Open Software License 1.1",
-      "licenseId": "OSL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
-      ]
-    },
-    {
-      "name": "Open Software License 2.0",
-      "licenseId": "OSL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
-      ]
-    },
-    {
-      "name": "Open Software License 2.1",
-      "licenseId": "OSL-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "https://opensource.org/licenses/OSL-2.1"
-      ]
-    },
-    {
-      "name": "Open Software License 3.0",
-      "licenseId": "OSL-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
-        "https://opensource.org/licenses/OSL-3.0"
-      ]
-    },
-    {
-      "name": "PADL License",
-      "licenseId": "PADL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://git.openldap.org/openldap/openldap/-/blob/master/libraries/libldap/os-local.c?ref_type=heads#L19-23"
-      ]
-    },
-    {
-      "name": "The Parity Public License 6.0.0",
-      "licenseId": "Parity-6.0.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://paritylicense.com/versions/6.0.0.html"
-      ]
-    },
-    {
-      "name": "The Parity Public License 7.0.0",
-      "licenseId": "Parity-7.0.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://paritylicense.com/versions/7.0.0.html"
-      ]
-    },
-    {
-      "name": "Open Data Commons Public Domain Dedication & License 1.0",
-      "licenseId": "PDDL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/",
-        "https://opendatacommons.org/licenses/pddl/"
-      ]
-    },
-    {
-      "name": "PHP License v3.0",
-      "licenseId": "PHP-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.php.net/license/3_0.txt",
-        "https://opensource.org/licenses/PHP-3.0"
-      ]
-    },
-    {
-      "name": "PHP License v3.01",
-      "licenseId": "PHP-3.01",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.php.net/license/3_01.txt"
-      ]
-    },
-    {
-      "name": "Pixar License",
-      "licenseId": "Pixar",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/PixarAnimationStudios/OpenSubdiv/raw/v3_5_0/LICENSE.txt",
-        "https://graphics.pixar.com/opensubdiv/docs/license.html",
-        "https://github.com/PixarAnimationStudios/OpenSubdiv/blob/v3_5_0/opensubdiv/version.cpp#L2-L22"
-      ]
-    },
-    {
-      "name": "pkgconf License",
-      "licenseId": "pkgconf",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/pkgconf/pkgconf/blob/master/cli/main.c#L8"
-      ]
-    },
-    {
-      "name": "Plexus Classworlds License",
-      "licenseId": "Plexus",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
-      ]
-    },
-    {
-      "name": "pnmstitch License",
-      "licenseId": "pnmstitch",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/editor/pnmstitch.c#l2"
-      ]
-    },
-    {
-      "name": "PolyForm Noncommercial License 1.0.0",
-      "licenseId": "PolyForm-Noncommercial-1.0.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://polyformproject.org/licenses/noncommercial/1.0.0"
-      ]
-    },
-    {
-      "name": "PolyForm Small Business License 1.0.0",
-      "licenseId": "PolyForm-Small-Business-1.0.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://polyformproject.org/licenses/small-business/1.0.0"
-      ]
-    },
-    {
-      "name": "PostgreSQL License",
-      "licenseId": "PostgreSQL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.postgresql.org/about/licence",
-        "https://opensource.org/licenses/PostgreSQL"
-      ]
-    },
-    {
-      "name": "Peer Production License",
-      "licenseId": "PPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://wiki.p2pfoundation.net/Peer_Production_License",
-        "http://www.networkcultures.org/_uploads/%233notebook_telekommunist.pdf"
-      ]
-    },
-    {
-      "name": "Python Software Foundation License 2.0",
-      "licenseId": "PSF-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0",
-        "https://matplotlib.org/stable/project/license.html"
-      ]
-    },
-    {
-      "name": "psfrag License",
-      "licenseId": "psfrag",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psfrag"
-      ]
-    },
-    {
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ]
-    },
-    {
-      "name": "Python License 2.0",
-      "licenseId": "Python-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0"
-      ]
-    },
-    {
-      "name": "Python License 2.0.1",
-      "licenseId": "Python-2.0.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.python.org/download/releases/2.0.1/license/",
-        "https://docs.python.org/3/license.html",
-        "https://github.com/python/cpython/blob/main/LICENSE"
-      ]
-    },
-    {
-      "name": "Python ldap License",
-      "licenseId": "python-ldap",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/python-ldap/python-ldap/blob/main/LICENCE"
-      ]
-    },
-    {
-      "name": "Qhull License",
-      "licenseId": "Qhull",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Qhull"
-      ]
-    },
-    {
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "https://opensource.org/licenses/QPL-1.0",
-        "https://doc.qt.io/archives/3.3/license.html"
-      ]
-    },
-    {
-      "name": "Q Public License 1.0 - INRIA 2004 variant",
-      "licenseId": "QPL-1.0-INRIA-2004",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/maranget/hevea/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "radvd License",
-      "licenseId": "radvd",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/radvd-project/radvd/blob/master/COPYRIGHT"
-      ]
-    },
-    {
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ]
-    },
-    {
-      "name": "Red Hat eCos Public License v1.1",
-      "licenseId": "RHeCos-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://ecos.sourceware.org/old-license.html"
-      ]
-    },
-    {
-      "name": "Reciprocal Public License 1.1",
-      "licenseId": "RPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.1"
-      ]
-    },
-    {
-      "name": "Reciprocal Public License 1.5",
-      "licenseId": "RPL-1.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.5"
-      ]
-    },
-    {
-      "name": "RealNetworks Public Source License v1.0",
-      "licenseId": "RPSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://helixcommunity.org/content/rpsl",
-        "https://opensource.org/licenses/RPSL-1.0"
-      ]
-    },
-    {
-      "name": "RSA Message-Digest License",
-      "licenseId": "RSA-MD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.faqs.org/rfcs/rfc1321.html"
-      ]
-    },
-    {
-      "name": "Ricoh Source Code Public License",
-      "licenseId": "RSCPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "https://opensource.org/licenses/RSCPL"
-      ]
-    },
-    {
-      "name": "Ruby License",
-      "licenseId": "Ruby",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.ruby-lang.org/en/about/license.txt"
-      ]
-    },
-    {
-      "name": "Ruby pty extension license",
-      "licenseId": "Ruby-pty",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786",
-        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204",
-        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0"
-      ]
-    },
-    {
-      "name": "Sax Public Domain Notice",
-      "licenseId": "SAX-PD",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.saxproject.org/copying.html"
-      ]
-    },
-    {
-      "name": "Sax Public Domain Notice 2.0",
-      "licenseId": "SAX-PD-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.saxproject.org/copying.html"
-      ]
-    },
-    {
-      "name": "Saxpath License",
-      "licenseId": "Saxpath",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
-      ]
-    },
-    {
-      "name": "SCEA Shared Source License",
-      "licenseId": "SCEA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://research.scea.com/scea_shared_source_license.html"
-      ]
-    },
-    {
-      "name": "Scheme Language Report License",
-      "licenseId": "SchemeReport",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": []
-    },
-    {
-      "name": "Sendmail License",
-      "licenseId": "Sendmail",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
-        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
-      ]
-    },
-    {
-      "name": "Sendmail License 8.23",
-      "licenseId": "Sendmail-8.23",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
-        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
-      ]
-    },
-    {
-      "name": "Sendmail Open Source License v1.1",
-      "licenseId": "Sendmail-Open-Source-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/trusteddomainproject/OpenDMARC/blob/master/LICENSE.Sendmail"
-      ]
-    },
-    {
-      "name": "SGI Free Software License B v1.0",
-      "licenseId": "SGI-B-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
-      ]
-    },
-    {
-      "name": "SGI Free Software License B v1.1",
-      "licenseId": "SGI-B-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/"
-      ]
-    },
-    {
-      "name": "SGI Free Software License B v2.0",
-      "licenseId": "SGI-B-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
-      ]
-    },
-    {
-      "name": "SGI OpenGL License",
-      "licenseId": "SGI-OpenGL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/mesa/glw/-/blob/master/README?ref_type=heads"
-      ]
-    },
-    {
-      "name": "SGP4 Permission Notice",
-      "licenseId": "SGP4",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://celestrak.org/publications/AIAA/2006-6753/faq.php"
-      ]
-    },
-    {
-      "name": "Solderpad Hardware License v0.5",
-      "licenseId": "SHL-0.5",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.5/"
-      ]
-    },
-    {
-      "name": "Solderpad Hardware License, Version 0.51",
-      "licenseId": "SHL-0.51",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.51/"
-      ]
-    },
-    {
-      "name": "Simple Public License 2.0",
-      "licenseId": "SimPL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/SimPL-2.0"
-      ]
-    },
-    {
-      "name": "Sun Industry Standards Source License v1.1",
-      "licenseId": "SISSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.openoffice.org/licenses/sissl_license.html",
-        "https://opensource.org/licenses/SISSL"
-      ]
-    },
-    {
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
-      ]
-    },
-    {
-      "name": "SL License",
-      "licenseId": "SL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/mtoyoda/sl/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "Sleepycat License",
-      "licenseId": "Sleepycat",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/Sleepycat"
-      ]
-    },
-    {
-      "name": "SMAIL General Public License",
-      "licenseId": "SMAIL-GPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sources.debian.org/copyright/license/debianutils/4.11.2/"
-      ]
-    },
-    {
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "SMLNJ",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ]
-    },
-    {
-      "name": "Secure Messaging Protocol Public License",
-      "licenseId": "SMPPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
-      ]
-    },
-    {
-      "name": "SNIA Public License 1.1",
-      "licenseId": "SNIA",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
-      ]
-    },
-    {
-      "name": "snprintf License",
-      "licenseId": "snprintf",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/master/openbsd-compat/bsd-snprintf.c#L2"
-      ]
-    },
-    {
-      "name": "softSurfer License",
-      "licenseId": "softSurfer",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/mm2/Little-CMS/blob/master/src/cmssm.c#L207",
-        "https://fedoraproject.org/wiki/Licensing/softSurfer"
-      ]
-    },
-    {
-      "name": "Soundex License",
-      "licenseId": "Soundex",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/release/RJBS/Text-Soundex-3.05/source/Soundex.pm#L3-11"
-      ]
-    },
-    {
-      "name": "Spencer License 86",
-      "licenseId": "Spencer-86",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ]
-    },
-    {
-      "name": "Spencer License 94",
-      "licenseId": "Spencer-94",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License",
-        "https://metacpan.org/release/KNOK/File-MMagic-1.30/source/COPYING#L28"
-      ]
-    },
-    {
-      "name": "Spencer License 99",
-      "licenseId": "Spencer-99",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
-      ]
-    },
-    {
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/SPL-1.0"
-      ]
-    },
-    {
-      "name": "ssh-keyscan License",
-      "licenseId": "ssh-keyscan",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/master/LICENCE#L82"
-      ]
-    },
-    {
-      "name": "SSH OpenSSH license",
-      "licenseId": "SSH-OpenSSH",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
-      ]
-    },
-    {
-      "name": "SSH short notice",
-      "licenseId": "SSH-short",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
-        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
-        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
-      ]
-    },
-    {
-      "name": "SSLeay License - standalone",
-      "licenseId": "SSLeay-standalone",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.tq-group.com/filedownloads/files/software-license-conditions/OriginalSSLeay/OriginalSSLeay.pdf"
-      ]
-    },
-    {
-      "name": "Server Side Public License, v 1",
-      "licenseId": "SSPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.mongodb.com/licensing/server-side-public-license"
-      ]
-    },
-    {
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "StandardML-NJ",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ]
-    },
-    {
-      "name": "SugarCRM Public License v1.1.3",
-      "licenseId": "SugarCRM-1.1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.sugarcrm.com/crm/SPL"
-      ]
-    },
-    {
-      "name": "Sun PPP License",
-      "licenseId": "Sun-PPP",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ppp-project/ppp/blob/master/pppd/eap.c#L7-L16"
-      ]
-    },
-    {
-      "name": "Sun PPP License (2000)",
-      "licenseId": "Sun-PPP-2000",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/ppp-project/ppp/blob/master/modules/ppp_ahdlc.c#L7-L19"
-      ]
-    },
-    {
-      "name": "SunPro License",
-      "licenseId": "SunPro",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_acosh.c",
-        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_lgammal.c"
-      ]
-    },
-    {
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
-      ]
-    },
-    {
-      "name": "swrule License",
-      "licenseId": "swrule",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/misc/swrule.sty"
-      ]
-    },
-    {
-      "name": "Symlinks License",
-      "licenseId": "Symlinks",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.mail-archive.com/debian-bugs-rc@lists.debian.org/msg11494.html"
-      ]
-    },
-    {
-      "name": "TAPR Open Hardware License v1.0",
-      "licenseId": "TAPR-OHL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.tapr.org/OHL"
-      ]
-    },
-    {
-      "name": "TCL/TK License",
-      "licenseId": "TCL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.tcl.tk/software/tcltk/license.html",
-        "https://fedoraproject.org/wiki/Licensing/TCL"
-      ]
-    },
-    {
-      "name": "TCP Wrappers License",
-      "licenseId": "TCP-wrappers",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
-      ]
-    },
-    {
-      "name": "TermReadKey License",
-      "licenseId": "TermReadKey",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/jonathanstowe/TermReadKey/blob/master/README#L9-L10"
-      ]
-    },
-    {
-      "name": "Transitive Grace Period Public Licence 1.0",
-      "licenseId": "TGPPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TGPPL",
-        "https://tahoe-lafs.org/trac/tahoe-lafs/browser/trunk/COPYING.TGPPL.rst"
-      ]
-    },
-    {
-      "name": "ThirdEye License",
-      "licenseId": "ThirdEye",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
-      ]
-    },
-    {
-      "name": "threeparttable License",
-      "licenseId": "threeparttable",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Threeparttable"
-      ]
-    },
-    {
-      "name": "TMate Open Source License",
-      "licenseId": "TMate",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://svnkit.com/license.html"
-      ]
-    },
-    {
-      "name": "TORQUE v2.5+ Software License v1.1",
-      "licenseId": "TORQUE-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
-      ]
-    },
-    {
-      "name": "Trusster Open Source License",
-      "licenseId": "TOSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TOSL"
-      ]
-    },
-    {
-      "name": "Time::ParseDate License",
-      "licenseId": "TPDL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metacpan.org/pod/Time::ParseDate#LICENSE"
-      ]
-    },
-    {
-      "name": "THOR Public License 1.0",
-      "licenseId": "TPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:ThorPublicLicense"
-      ]
-    },
-    {
-      "name": "TrustedQSL License",
-      "licenseId": "TrustedQSL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/trustedqsl/tqsl/ci/master/tree/LICENSE.txt"
-      ]
-    },
-    {
-      "name": "Text-Tabs+Wrap License",
-      "licenseId": "TTWL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TTWL",
-        "https://github.com/ap/Text-Tabs/blob/master/lib.modern/Text/Tabs.pm#L148"
-      ]
-    },
-    {
-      "name": "TTYP0 License",
-      "licenseId": "TTYP0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/"
-      ]
-    },
-    {
-      "name": "Technische Universitaet Berlin License 1.0",
-      "licenseId": "TU-Berlin-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
-      ]
-    },
-    {
-      "name": "Technische Universitaet Berlin License 2.0",
-      "licenseId": "TU-Berlin-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
-      ]
-    },
-    {
-      "name": "Ubuntu Font Licence v1.0",
-      "licenseId": "Ubuntu-font-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://ubuntu.com/legal/font-licence",
-        "https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt"
-      ]
-    },
-    {
-      "name": "UCAR License",
-      "licenseId": "UCAR",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Unidata/UDUNITS-2/blob/master/COPYRIGHT"
-      ]
-    },
-    {
-      "name": "Upstream Compatibility License v1.0",
-      "licenseId": "UCL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/UCL-1.0"
-      ]
-    },
-    {
-      "name": "ulem License",
-      "licenseId": "ulem",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://mirrors.ctan.org/macros/latex/contrib/ulem/README"
-      ]
-    },
-    {
-      "name": "Michigan/Merit Networks License",
-      "licenseId": "UMich-Merit",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L64"
-      ]
-    },
-    {
-      "name": "Unicode License v3",
-      "licenseId": "Unicode-3.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.unicode.org/license.txt"
-      ]
-    },
-    {
-      "name": "Unicode License Agreement - Data Files and Software (2015)",
-      "licenseId": "Unicode-DFS-2015",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
-      ]
-    },
-    {
-      "name": "Unicode License Agreement - Data Files and Software (2016)",
-      "licenseId": "Unicode-DFS-2016",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.unicode.org/license.txt",
-        "http://web.archive.org/web/20160823201924/http://www.unicode.org/copyright.html#License",
-        "http://www.unicode.org/copyright.html"
-      ]
-    },
-    {
-      "name": "Unicode Terms of Use",
-      "licenseId": "Unicode-TOU",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://web.archive.org/web/20140704074106/http://www.unicode.org/copyright.html",
-        "http://www.unicode.org/copyright.html"
-      ]
-    },
-    {
-      "name": "UnixCrypt License",
-      "licenseId": "UnixCrypt",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/LICENSE#L70",
-        "https://opensource.apple.com/source/JBoss/JBoss-737/jboss-all/jetty/src/main/org/mortbay/util/UnixCrypt.java.auto.html",
-        "https://archive.eclipse.org/jetty/8.0.1.v20110908/xref/org/eclipse/jetty/http/security/UnixCrypt.html"
-      ]
-    },
-    {
-      "name": "The Unlicense",
-      "licenseId": "Unlicense",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://unlicense.org/"
-      ]
-    },
-    {
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://opensource.org/licenses/UPL"
-      ]
-    },
-    {
-      "name": "Utah Raster Toolkit Run Length Encoded License",
-      "licenseId": "URT-RLE",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/pnmtorle.c",
-        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/rletopnm.c"
-      ]
-    },
-    {
-      "name": "Vim License",
-      "licenseId": "Vim",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
-      ]
-    },
-    {
-      "name": "VOSTROM Public License for Open Source",
-      "licenseId": "VOSTROM",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
-      ]
-    },
-    {
-      "name": "Vovida Software License v1.0",
-      "licenseId": "VSL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/VSL-1.0"
-      ]
-    },
-    {
-      "name": "W3C Software Notice and License (2002-12-31)",
-      "licenseId": "W3C",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "https://opensource.org/licenses/W3C"
-      ]
-    },
-    {
-      "name": "W3C Software Notice and License (1998-07-20)",
-      "licenseId": "W3C-19980720",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
-      ]
-    },
-    {
-      "name": "W3C Software Notice and Document License (2015-05-13)",
-      "licenseId": "W3C-20150513",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
-        "https://www.w3.org/copyright/software-license-2015/",
-        "https://www.w3.org/copyright/software-license-2023/"
-      ]
-    },
-    {
-      "name": "w3m License",
-      "licenseId": "w3m",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/tats/w3m/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "Sybase Open Watcom Public License 1.0",
-      "licenseId": "Watcom-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Watcom-1.0"
-      ]
-    },
-    {
-      "name": "Widget Workshop License",
-      "licenseId": "Widget-Workshop",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/novnc/noVNC/blob/master/core/crypto/des.js#L24"
-      ]
-    },
-    {
-      "name": "Wsuipa License",
-      "licenseId": "Wsuipa",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
-      ]
-    },
-    {
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.wtfpl.net/about/",
-        "http://sam.zoy.org/wtfpl/COPYING"
-      ]
-    },
-    {
-      "name": "WWL License",
-      "licenseId": "wwl",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.db.net/downloads/wwl+db-1.3.tgz"
-      ]
-    },
-    {
-      "name": "wxWindows Library License",
-      "licenseId": "wxWindows",
-      "isDeprecatedLicenseId": true,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/WXwindows"
-      ]
-    },
-    {
-      "name": "X11 License",
-      "licenseId": "X11",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
-      ]
-    },
-    {
-      "name": "X11 License Distribution Modification Variant",
-      "licenseId": "X11-distribute-modifications-variant",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/mirror/ncurses/blob/master/COPYING"
-      ]
-    },
-    {
-      "name": "X11 swapped final paragraphs",
-      "licenseId": "X11-swapped",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE"
-      ]
-    },
-    {
-      "name": "Xdebug License v 1.03",
-      "licenseId": "Xdebug-1.03",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/xdebug/xdebug/blob/master/LICENSE"
-      ]
-    },
-    {
-      "name": "Xerox License",
-      "licenseId": "Xerox",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xerox"
-      ]
-    },
-    {
-      "name": "Xfig License",
-      "licenseId": "Xfig",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://github.com/Distrotech/transfig/blob/master/transfig/transfig.c",
-        "https://fedoraproject.org/wiki/Licensing:MIT#Xfig_Variant",
-        "https://sourceforge.net/p/mcj/xfig/ci/master/tree/src/Makefile.am"
-      ]
-    },
-    {
-      "name": "XFree86 License 1.1",
-      "licenseId": "XFree86-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.xfree86.org/current/LICENSE4.html"
-      ]
-    },
-    {
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ]
-    },
-    {
-      "name": "xkeyboard-config Zinoviev License",
-      "licenseId": "xkeyboard-config-Zinoviev",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/COPYING?ref_type=heads#L178"
-      ]
-    },
-    {
-      "name": "xlock License",
-      "licenseId": "xlock",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fossies.org/linux/tiff/contrib/ras/ras2tif.c"
-      ]
-    },
-    {
-      "name": "X.Net License",
-      "licenseId": "Xnet",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://opensource.org/licenses/Xnet"
-      ]
-    },
-    {
-      "name": "XPP License",
-      "licenseId": "xpp",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/xpp"
-      ]
-    },
-    {
-      "name": "XSkat License",
-      "licenseId": "XSkat",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
-      ]
-    },
-    {
-      "name": "xzoom License",
-      "licenseId": "xzoom",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://metadata.ftp-master.debian.org/changelogs//main/x/xzoom/xzoom_0.3-27_copyright"
-      ]
-    },
-    {
-      "name": "Yahoo! Public License v1.0",
-      "licenseId": "YPL-1.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
-      ]
-    },
-    {
-      "name": "Yahoo! Public License v1.1",
-      "licenseId": "YPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
-      ]
-    },
-    {
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ]
-    },
-    {
-      "name": "Zeeff License",
-      "licenseId": "Zeeff",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "ftp://ftp.tin.org/pub/news/utils/newsx/newsx-1.6.tar.gz"
-      ]
-    },
-    {
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ]
-    },
-    {
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-      ]
-    },
-    {
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ]
-    },
-    {
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "https://opensource.org/licenses/Zlib"
-      ]
-    },
-    {
-      "name": "zlib/libpng License with Acknowledgement",
-      "licenseId": "zlib-acknowledgement",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
-      ]
-    },
-    {
-      "name": "Zope Public License 1.1",
-      "licenseId": "ZPL-1.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": false,
-      "isFsfLibre": false,
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-1.1"
-      ]
-    },
-    {
-      "name": "Zope Public License 2.0",
-      "licenseId": "ZPL-2.0",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-2.0",
-        "https://opensource.org/licenses/ZPL-2.0"
-      ]
-    },
-    {
-      "name": "Zope Public License 2.1",
-      "licenseId": "ZPL-2.1",
-      "isDeprecatedLicenseId": false,
-      "isOsiApproved": true,
-      "isFsfLibre": true,
-      "seeAlso": [
-        "http://old.zope.org/Resources/ZPL/"
-      ]
-    }
-  ],
-  "releaseDate": "2025-05-12T00:00:00Z"
-}
+[
+  {
+    "name": "BSD Zero Clause License",
+    "licenseId": "0BSD",
+    "deprecated": false
+  },
+  {
+    "name": "3D Slicer License v1.0",
+    "licenseId": "3D-Slicer-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Attribution Assurance License",
+    "licenseId": "AAL",
+    "deprecated": false
+  },
+  {
+    "name": "Abstyles License",
+    "licenseId": "Abstyles",
+    "deprecated": false
+  },
+  {
+    "name": "AdaCore Doc License",
+    "licenseId": "AdaCore-doc",
+    "deprecated": false
+  },
+  {
+    "name": "Adobe Systems Incorporated Source Code License Agreement",
+    "licenseId": "Adobe-2006",
+    "deprecated": false
+  },
+  {
+    "name": "Adobe Display PostScript License",
+    "licenseId": "Adobe-Display-PostScript",
+    "deprecated": false
+  },
+  {
+    "name": "Adobe Glyph List License",
+    "licenseId": "Adobe-Glyph",
+    "deprecated": false
+  },
+  {
+    "name": "Adobe Utopia Font License",
+    "licenseId": "Adobe-Utopia",
+    "deprecated": false
+  },
+  {
+    "name": "Amazon Digital Services License",
+    "licenseId": "ADSL",
+    "deprecated": false
+  },
+  {
+    "name": "Academic Free License v1.1",
+    "licenseId": "AFL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Academic Free License v1.2",
+    "licenseId": "AFL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "Academic Free License v2.0",
+    "licenseId": "AFL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Academic Free License v2.1",
+    "licenseId": "AFL-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Academic Free License v3.0",
+    "licenseId": "AFL-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Afmparse License",
+    "licenseId": "Afmparse",
+    "deprecated": false
+  },
+  {
+    "name": "Affero General Public License v1.0",
+    "licenseId": "AGPL-1.0",
+    "deprecated": true
+  },
+  {
+    "name": "Affero General Public License v1.0 only",
+    "licenseId": "AGPL-1.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "Affero General Public License v1.0 or later",
+    "licenseId": "AGPL-1.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Affero General Public License v3.0",
+    "licenseId": "AGPL-3.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Affero General Public License v3.0 only",
+    "licenseId": "AGPL-3.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Affero General Public License v3.0 or later",
+    "licenseId": "AGPL-3.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "Aladdin Free Public License",
+    "licenseId": "Aladdin",
+    "deprecated": false
+  },
+  {
+    "name": "AMD newlib License",
+    "licenseId": "AMD-newlib",
+    "deprecated": false
+  },
+  {
+    "name": "AMD's plpa_map.c License",
+    "licenseId": "AMDPLPA",
+    "deprecated": false
+  },
+  {
+    "name": "Apple MIT License",
+    "licenseId": "AML",
+    "deprecated": false
+  },
+  {
+    "name": "AML glslang variant License",
+    "licenseId": "AML-glslang",
+    "deprecated": false
+  },
+  {
+    "name": "Academy of Motion Picture Arts and Sciences BSD",
+    "licenseId": "AMPAS",
+    "deprecated": false
+  },
+  {
+    "name": "ANTLR Software Rights Notice",
+    "licenseId": "ANTLR-PD",
+    "deprecated": false
+  },
+  {
+    "name": "ANTLR Software Rights Notice with license fallback",
+    "licenseId": "ANTLR-PD-fallback",
+    "deprecated": false
+  },
+  {
+    "name": "Any OSI License",
+    "licenseId": "any-OSI",
+    "deprecated": false
+  },
+  {
+    "name": "Any OSI License - Perl Modules",
+    "licenseId": "any-OSI-perl-modules",
+    "deprecated": false
+  },
+  {
+    "name": "Apache License 1.0",
+    "licenseId": "Apache-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Apache License 1.1",
+    "licenseId": "Apache-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Apache License 2.0",
+    "licenseId": "Apache-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Adobe Postscript AFM License",
+    "licenseId": "APAFML",
+    "deprecated": false
+  },
+  {
+    "name": "Adaptive Public License 1.0",
+    "licenseId": "APL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "App::s2p License",
+    "licenseId": "App-s2p",
+    "deprecated": false
+  },
+  {
+    "name": "Apple Public Source License 1.0",
+    "licenseId": "APSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Apple Public Source License 1.1",
+    "licenseId": "APSL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Apple Public Source License 1.2",
+    "licenseId": "APSL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "Apple Public Source License 2.0",
+    "licenseId": "APSL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Arphic Public License",
+    "licenseId": "Arphic-1999",
+    "deprecated": false
+  },
+  {
+    "name": "Artistic License 1.0",
+    "licenseId": "Artistic-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Artistic License 1.0 w/clause 8",
+    "licenseId": "Artistic-1.0-cl8",
+    "deprecated": false
+  },
+  {
+    "name": "Artistic License 1.0 (Perl)",
+    "licenseId": "Artistic-1.0-Perl",
+    "deprecated": false
+  },
+  {
+    "name": "Artistic License 2.0",
+    "licenseId": "Artistic-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Artistic License 1.0 (dist)",
+    "licenseId": "Artistic-dist",
+    "deprecated": false
+  },
+  {
+    "name": "Aspell Russian License",
+    "licenseId": "Aspell-RU",
+    "deprecated": false
+  },
+  {
+    "name": "ASWF Digital Assets License version 1.0",
+    "licenseId": "ASWF-Digital-Assets-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "ASWF Digital Assets License 1.1",
+    "licenseId": "ASWF-Digital-Assets-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Baekmuk License",
+    "licenseId": "Baekmuk",
+    "deprecated": false
+  },
+  {
+    "name": "Bahyph License",
+    "licenseId": "Bahyph",
+    "deprecated": false
+  },
+  {
+    "name": "Barr License",
+    "licenseId": "Barr",
+    "deprecated": false
+  },
+  {
+    "name": "bcrypt Solar Designer License",
+    "licenseId": "bcrypt-Solar-Designer",
+    "deprecated": false
+  },
+  {
+    "name": "Beerware License",
+    "licenseId": "Beerware",
+    "deprecated": false
+  },
+  {
+    "name": "Bitstream Charter Font License",
+    "licenseId": "Bitstream-Charter",
+    "deprecated": false
+  },
+  {
+    "name": "Bitstream Vera Font License",
+    "licenseId": "Bitstream-Vera",
+    "deprecated": false
+  },
+  {
+    "name": "BitTorrent Open Source License v1.0",
+    "licenseId": "BitTorrent-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "BitTorrent Open Source License v1.1",
+    "licenseId": "BitTorrent-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "SQLite Blessing",
+    "licenseId": "blessing",
+    "deprecated": false
+  },
+  {
+    "name": "Blue Oak Model License 1.0.0",
+    "licenseId": "BlueOak-1.0.0",
+    "deprecated": false
+  },
+  {
+    "name": "Boehm-Demers-Weiser GC License",
+    "licenseId": "Boehm-GC",
+    "deprecated": false
+  },
+  {
+    "name": "Boehm-Demers-Weiser GC License (without fee)",
+    "licenseId": "Boehm-GC-without-fee",
+    "deprecated": false
+  },
+  {
+    "name": "Borceux license",
+    "licenseId": "Borceux",
+    "deprecated": false
+  },
+  {
+    "name": "Brian Gladman 2-Clause License",
+    "licenseId": "Brian-Gladman-2-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "Brian Gladman 3-Clause License",
+    "licenseId": "Brian-Gladman-3-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 1-Clause License",
+    "licenseId": "BSD-1-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause \"Simplified\" License",
+    "licenseId": "BSD-2-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause - Ian Darwin variant",
+    "licenseId": "BSD-2-Clause-Darwin",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause - first lines requirement",
+    "licenseId": "BSD-2-Clause-first-lines",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause FreeBSD License",
+    "licenseId": "BSD-2-Clause-FreeBSD",
+    "deprecated": true
+  },
+  {
+    "name": "BSD 2-Clause NetBSD License",
+    "licenseId": "BSD-2-Clause-NetBSD",
+    "deprecated": true
+  },
+  {
+    "name": "BSD-2-Clause Plus Patent License",
+    "licenseId": "BSD-2-Clause-Patent",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause pkgconf disclaimer variant",
+    "licenseId": "BSD-2-Clause-pkgconf-disclaimer",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 2-Clause with views sentence",
+    "licenseId": "BSD-2-Clause-Views",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+    "licenseId": "BSD-3-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause acpica variant",
+    "licenseId": "BSD-3-Clause-acpica",
+    "deprecated": false
+  },
+  {
+    "name": "BSD with attribution",
+    "licenseId": "BSD-3-Clause-Attribution",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause Clear License",
+    "licenseId": "BSD-3-Clause-Clear",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause Flex variant",
+    "licenseId": "BSD-3-Clause-flex",
+    "deprecated": false
+  },
+  {
+    "name": "Hewlett-Packard BSD variant license",
+    "licenseId": "BSD-3-Clause-HP",
+    "deprecated": false
+  },
+  {
+    "name": "Lawrence Berkeley National Labs BSD variant license",
+    "licenseId": "BSD-3-Clause-LBNL",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause Modification",
+    "licenseId": "BSD-3-Clause-Modification",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause No Military License",
+    "licenseId": "BSD-3-Clause-No-Military-License",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear License",
+    "licenseId": "BSD-3-Clause-No-Nuclear-License",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear License 2014",
+    "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear Warranty",
+    "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause Open MPI variant",
+    "licenseId": "BSD-3-Clause-Open-MPI",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 3-Clause Sun Microsystems",
+    "licenseId": "BSD-3-Clause-Sun",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+    "licenseId": "BSD-4-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 4 Clause Shortened",
+    "licenseId": "BSD-4-Clause-Shortened",
+    "deprecated": false
+  },
+  {
+    "name": "BSD-4-Clause (University of California-Specific)",
+    "licenseId": "BSD-4-Clause-UC",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 4.3 RENO License",
+    "licenseId": "BSD-4.3RENO",
+    "deprecated": false
+  },
+  {
+    "name": "BSD 4.3 TAHOE License",
+    "licenseId": "BSD-4.3TAHOE",
+    "deprecated": false
+  },
+  {
+    "name": "BSD Advertising Acknowledgement License",
+    "licenseId": "BSD-Advertising-Acknowledgement",
+    "deprecated": false
+  },
+  {
+    "name": "BSD with Attribution and HPND disclaimer",
+    "licenseId": "BSD-Attribution-HPND-disclaimer",
+    "deprecated": false
+  },
+  {
+    "name": "BSD-Inferno-Nettverk",
+    "licenseId": "BSD-Inferno-Nettverk",
+    "deprecated": false
+  },
+  {
+    "name": "BSD Protection License",
+    "licenseId": "BSD-Protection",
+    "deprecated": false
+  },
+  {
+    "name": "BSD Source Code Attribution - beginning of file variant",
+    "licenseId": "BSD-Source-beginning-file",
+    "deprecated": false
+  },
+  {
+    "name": "BSD Source Code Attribution",
+    "licenseId": "BSD-Source-Code",
+    "deprecated": false
+  },
+  {
+    "name": "Systemics BSD variant license",
+    "licenseId": "BSD-Systemics",
+    "deprecated": false
+  },
+  {
+    "name": "Systemics W3Works BSD variant license",
+    "licenseId": "BSD-Systemics-W3Works",
+    "deprecated": false
+  },
+  {
+    "name": "Boost Software License 1.0",
+    "licenseId": "BSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Business Source License 1.1",
+    "licenseId": "BUSL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "bzip2 and libbzip2 License v1.0.5",
+    "licenseId": "bzip2-1.0.5",
+    "deprecated": true
+  },
+  {
+    "name": "bzip2 and libbzip2 License v1.0.6",
+    "licenseId": "bzip2-1.0.6",
+    "deprecated": false
+  },
+  {
+    "name": "Computational Use of Data Agreement v1.0",
+    "licenseId": "C-UDA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Cryptographic Autonomy License 1.0",
+    "licenseId": "CAL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+    "licenseId": "CAL-1.0-Combined-Work-Exception",
+    "deprecated": false
+  },
+  {
+    "name": "Caldera License",
+    "licenseId": "Caldera",
+    "deprecated": false
+  },
+  {
+    "name": "Caldera License (without preamble)",
+    "licenseId": "Caldera-no-preamble",
+    "deprecated": false
+  },
+  {
+    "name": "Catharon License",
+    "licenseId": "Catharon",
+    "deprecated": false
+  },
+  {
+    "name": "Computer Associates Trusted Open Source License 1.1",
+    "licenseId": "CATOSL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 1.0 Generic",
+    "licenseId": "CC-BY-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 2.0 Generic",
+    "licenseId": "CC-BY-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 2.5 Generic",
+    "licenseId": "CC-BY-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 2.5 Australia",
+    "licenseId": "CC-BY-2.5-AU",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Unported",
+    "licenseId": "CC-BY-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Austria",
+    "licenseId": "CC-BY-3.0-AT",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Australia",
+    "licenseId": "CC-BY-3.0-AU",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Germany",
+    "licenseId": "CC-BY-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 IGO",
+    "licenseId": "CC-BY-3.0-IGO",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Netherlands",
+    "licenseId": "CC-BY-3.0-NL",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 United States",
+    "licenseId": "CC-BY-3.0-US",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution 4.0 International",
+    "licenseId": "CC-BY-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+    "licenseId": "CC-BY-NC-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+    "licenseId": "CC-BY-NC-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+    "licenseId": "CC-BY-NC-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+    "licenseId": "CC-BY-NC-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
+    "licenseId": "CC-BY-NC-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 4.0 International",
+    "licenseId": "CC-BY-NC-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+    "licenseId": "CC-BY-NC-ND-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+    "licenseId": "CC-BY-NC-ND-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+    "licenseId": "CC-BY-NC-ND-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+    "licenseId": "CC-BY-NC-ND-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
+    "licenseId": "CC-BY-NC-ND-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+    "licenseId": "CC-BY-NC-ND-3.0-IGO",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+    "licenseId": "CC-BY-NC-ND-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+    "licenseId": "CC-BY-NC-SA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+    "licenseId": "CC-BY-NC-SA-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
+    "licenseId": "CC-BY-NC-SA-2.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
+    "licenseId": "CC-BY-NC-SA-2.0-FR",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
+    "licenseId": "CC-BY-NC-SA-2.0-UK",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+    "licenseId": "CC-BY-NC-SA-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+    "licenseId": "CC-BY-NC-SA-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
+    "licenseId": "CC-BY-NC-SA-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
+    "licenseId": "CC-BY-NC-SA-3.0-IGO",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+    "licenseId": "CC-BY-NC-SA-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
+    "licenseId": "CC-BY-ND-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+    "licenseId": "CC-BY-ND-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+    "licenseId": "CC-BY-ND-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+    "licenseId": "CC-BY-ND-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
+    "licenseId": "CC-BY-ND-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 4.0 International",
+    "licenseId": "CC-BY-ND-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+    "licenseId": "CC-BY-SA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+    "licenseId": "CC-BY-SA-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+    "licenseId": "CC-BY-SA-2.0-UK",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+    "licenseId": "CC-BY-SA-2.1-JP",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+    "licenseId": "CC-BY-SA-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+    "licenseId": "CC-BY-SA-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Austria",
+    "licenseId": "CC-BY-SA-3.0-AT",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Germany",
+    "licenseId": "CC-BY-SA-3.0-DE",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
+    "licenseId": "CC-BY-SA-3.0-IGO",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 4.0 International",
+    "licenseId": "CC-BY-SA-4.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Public Domain Dedication and Certification",
+    "licenseId": "CC-PDDC",
+    "deprecated": false
+  },
+  {
+    "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+    "licenseId": "CC-PDM-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Share Alike 1.0 Generic",
+    "licenseId": "CC-SA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Creative Commons Zero v1.0 Universal",
+    "licenseId": "CC0-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Common Development and Distribution License 1.0",
+    "licenseId": "CDDL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Common Development and Distribution License 1.1",
+    "licenseId": "CDDL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Common Documentation License 1.0",
+    "licenseId": "CDL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Community Data License Agreement Permissive 1.0",
+    "licenseId": "CDLA-Permissive-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Community Data License Agreement Permissive 2.0",
+    "licenseId": "CDLA-Permissive-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Community Data License Agreement Sharing 1.0",
+    "licenseId": "CDLA-Sharing-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v1.0",
+    "licenseId": "CECILL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v1.1",
+    "licenseId": "CECILL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v2.0",
+    "licenseId": "CECILL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v2.1",
+    "licenseId": "CECILL-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL-B Free Software License Agreement",
+    "licenseId": "CECILL-B",
+    "deprecated": false
+  },
+  {
+    "name": "CeCILL-C Free Software License Agreement",
+    "licenseId": "CECILL-C",
+    "deprecated": false
+  },
+  {
+    "name": "CERN Open Hardware Licence v1.1",
+    "licenseId": "CERN-OHL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "CERN Open Hardware Licence v1.2",
+    "licenseId": "CERN-OHL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Permissive",
+    "licenseId": "CERN-OHL-P-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+    "licenseId": "CERN-OHL-S-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+    "licenseId": "CERN-OHL-W-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "CFITSIO License",
+    "licenseId": "CFITSIO",
+    "deprecated": false
+  },
+  {
+    "name": "check-cvs License",
+    "licenseId": "check-cvs",
+    "deprecated": false
+  },
+  {
+    "name": "Checkmk License",
+    "licenseId": "checkmk",
+    "deprecated": false
+  },
+  {
+    "name": "Clarified Artistic License",
+    "licenseId": "ClArtistic",
+    "deprecated": false
+  },
+  {
+    "name": "Clips License",
+    "licenseId": "Clips",
+    "deprecated": false
+  },
+  {
+    "name": "CMU Mach License",
+    "licenseId": "CMU-Mach",
+    "deprecated": false
+  },
+  {
+    "name": "CMU    Mach - no notices-in-documentation variant",
+    "licenseId": "CMU-Mach-nodoc",
+    "deprecated": false
+  },
+  {
+    "name": "CNRI Jython License",
+    "licenseId": "CNRI-Jython",
+    "deprecated": false
+  },
+  {
+    "name": "CNRI Python License",
+    "licenseId": "CNRI-Python",
+    "deprecated": false
+  },
+  {
+    "name": "CNRI Python Open Source GPL Compatible License Agreement",
+    "licenseId": "CNRI-Python-GPL-Compatible",
+    "deprecated": false
+  },
+  {
+    "name": "Copyfree Open Innovation License",
+    "licenseId": "COIL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Community Specification License 1.0",
+    "licenseId": "Community-Spec-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Condor Public License v1.1",
+    "licenseId": "Condor-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "copyleft-next 0.3.0",
+    "licenseId": "copyleft-next-0.3.0",
+    "deprecated": false
+  },
+  {
+    "name": "copyleft-next 0.3.1",
+    "licenseId": "copyleft-next-0.3.1",
+    "deprecated": false
+  },
+  {
+    "name": "Cornell Lossless JPEG License",
+    "licenseId": "Cornell-Lossless-JPEG",
+    "deprecated": false
+  },
+  {
+    "name": "Common Public Attribution License 1.0",
+    "licenseId": "CPAL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Common Public License 1.0",
+    "licenseId": "CPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Code Project Open License 1.02",
+    "licenseId": "CPOL-1.02",
+    "deprecated": false
+  },
+  {
+    "name": "Cronyx License",
+    "licenseId": "Cronyx",
+    "deprecated": false
+  },
+  {
+    "name": "Crossword License",
+    "licenseId": "Crossword",
+    "deprecated": false
+  },
+  {
+    "name": "CryptoSwift License",
+    "licenseId": "CryptoSwift",
+    "deprecated": false
+  },
+  {
+    "name": "CrystalStacker License",
+    "licenseId": "CrystalStacker",
+    "deprecated": false
+  },
+  {
+    "name": "CUA Office Public License v1.0",
+    "licenseId": "CUA-OPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Cube License",
+    "licenseId": "Cube",
+    "deprecated": false
+  },
+  {
+    "name": "curl License",
+    "licenseId": "curl",
+    "deprecated": false
+  },
+  {
+    "name": "Common Vulnerability Enumeration ToU License",
+    "licenseId": "cve-tou",
+    "deprecated": false
+  },
+  {
+    "name": "Deutsche Freie Software Lizenz",
+    "licenseId": "D-FSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "DEC 3-Clause License",
+    "licenseId": "DEC-3-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "diffmark license",
+    "licenseId": "diffmark",
+    "deprecated": false
+  },
+  {
+    "name": "Data licence Germany  attribution  version 2.0",
+    "licenseId": "DL-DE-BY-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Data licence Germany  zero  version 2.0",
+    "licenseId": "DL-DE-ZERO-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "DOC License",
+    "licenseId": "DOC",
+    "deprecated": false
+  },
+  {
+    "name": "DocBook DTD License",
+    "licenseId": "DocBook-DTD",
+    "deprecated": false
+  },
+  {
+    "name": "DocBook Schema License",
+    "licenseId": "DocBook-Schema",
+    "deprecated": false
+  },
+  {
+    "name": "DocBook Stylesheet License",
+    "licenseId": "DocBook-Stylesheet",
+    "deprecated": false
+  },
+  {
+    "name": "DocBook XML License",
+    "licenseId": "DocBook-XML",
+    "deprecated": false
+  },
+  {
+    "name": "Dotseqn License",
+    "licenseId": "Dotseqn",
+    "deprecated": false
+  },
+  {
+    "name": "Detection Rule License 1.0",
+    "licenseId": "DRL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Detection Rule License 1.1",
+    "licenseId": "DRL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "DSDP License",
+    "licenseId": "DSDP",
+    "deprecated": false
+  },
+  {
+    "name": "David M. Gay dtoa License",
+    "licenseId": "dtoa",
+    "deprecated": false
+  },
+  {
+    "name": "dvipdfm License",
+    "licenseId": "dvipdfm",
+    "deprecated": false
+  },
+  {
+    "name": "Educational Community License v1.0",
+    "licenseId": "ECL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Educational Community License v2.0",
+    "licenseId": "ECL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "eCos license version 2.0",
+    "licenseId": "eCos-2.0",
+    "deprecated": true
+  },
+  {
+    "name": "Eiffel Forum License v1.0",
+    "licenseId": "EFL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Eiffel Forum License v2.0",
+    "licenseId": "EFL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "eGenix.com Public License 1.1.0",
+    "licenseId": "eGenix",
+    "deprecated": false
+  },
+  {
+    "name": "Elastic License 2.0",
+    "licenseId": "Elastic-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Entessa Public License v1.0",
+    "licenseId": "Entessa",
+    "deprecated": false
+  },
+  {
+    "name": "EPICS Open License",
+    "licenseId": "EPICS",
+    "deprecated": false
+  },
+  {
+    "name": "Eclipse Public License 1.0",
+    "licenseId": "EPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Eclipse Public License 2.0",
+    "licenseId": "EPL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Erlang Public License v1.1",
+    "licenseId": "ErlPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Etalab Open License 2.0",
+    "licenseId": "etalab-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "EU DataGrid Software License",
+    "licenseId": "EUDatagrid",
+    "deprecated": false
+  },
+  {
+    "name": "European Union Public License 1.0",
+    "licenseId": "EUPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "European Union Public License 1.1",
+    "licenseId": "EUPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "European Union Public License 1.2",
+    "licenseId": "EUPL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "Eurosym License",
+    "licenseId": "Eurosym",
+    "deprecated": false
+  },
+  {
+    "name": "Fair License",
+    "licenseId": "Fair",
+    "deprecated": false
+  },
+  {
+    "name": "Fuzzy Bitmap License",
+    "licenseId": "FBM",
+    "deprecated": false
+  },
+  {
+    "name": "Fraunhofer FDK AAC Codec Library",
+    "licenseId": "FDK-AAC",
+    "deprecated": false
+  },
+  {
+    "name": "Ferguson Twofish License",
+    "licenseId": "Ferguson-Twofish",
+    "deprecated": false
+  },
+  {
+    "name": "Frameworx Open License 1.0",
+    "licenseId": "Frameworx-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "FreeBSD Documentation License",
+    "licenseId": "FreeBSD-DOC",
+    "deprecated": false
+  },
+  {
+    "name": "FreeImage Public License v1.0",
+    "licenseId": "FreeImage",
+    "deprecated": false
+  },
+  {
+    "name": "FSF All Permissive License",
+    "licenseId": "FSFAP",
+    "deprecated": false
+  },
+  {
+    "name": "FSF All Permissive License (without Warranty)",
+    "licenseId": "FSFAP-no-warranty-disclaimer",
+    "deprecated": false
+  },
+  {
+    "name": "FSF Unlimited License",
+    "licenseId": "FSFUL",
+    "deprecated": false
+  },
+  {
+    "name": "FSF Unlimited License (with License Retention)",
+    "licenseId": "FSFULLR",
+    "deprecated": false
+  },
+  {
+    "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
+    "licenseId": "FSFULLRSD",
+    "deprecated": false
+  },
+  {
+    "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
+    "licenseId": "FSFULLRWD",
+    "deprecated": false
+  },
+  {
+    "name": "Functional Source License, Version 1.1, ALv2 Future License",
+    "licenseId": "FSL-1.1-ALv2",
+    "deprecated": false
+  },
+  {
+    "name": "Functional Source License, Version 1.1, MIT Future License",
+    "licenseId": "FSL-1.1-MIT",
+    "deprecated": false
+  },
+  {
+    "name": "Freetype Project License",
+    "licenseId": "FTL",
+    "deprecated": false
+  },
+  {
+    "name": "Furuseth License",
+    "licenseId": "Furuseth",
+    "deprecated": false
+  },
+  {
+    "name": "fwlw License",
+    "licenseId": "fwlw",
+    "deprecated": false
+  },
+  {
+    "name": "Game Programming Gems License",
+    "licenseId": "Game-Programming-Gems",
+    "deprecated": false
+  },
+  {
+    "name": "Gnome GCR Documentation License",
+    "licenseId": "GCR-docs",
+    "deprecated": false
+  },
+  {
+    "name": "GD License",
+    "licenseId": "GD",
+    "deprecated": false
+  },
+  {
+    "name": "Generic XTS License",
+    "licenseId": "generic-xts",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1",
+    "licenseId": "GFDL-1.1",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only - invariants",
+    "licenseId": "GFDL-1.1-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later - invariants",
+    "licenseId": "GFDL-1.1-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only - no invariants",
+    "licenseId": "GFDL-1.1-no-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later - no invariants",
+    "licenseId": "GFDL-1.1-no-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only",
+    "licenseId": "GFDL-1.1-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later",
+    "licenseId": "GFDL-1.1-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2",
+    "licenseId": "GFDL-1.2",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only - invariants",
+    "licenseId": "GFDL-1.2-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later - invariants",
+    "licenseId": "GFDL-1.2-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only - no invariants",
+    "licenseId": "GFDL-1.2-no-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later - no invariants",
+    "licenseId": "GFDL-1.2-no-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only",
+    "licenseId": "GFDL-1.2-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later",
+    "licenseId": "GFDL-1.2-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3",
+    "licenseId": "GFDL-1.3",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only - invariants",
+    "licenseId": "GFDL-1.3-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later - invariants",
+    "licenseId": "GFDL-1.3-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only - no invariants",
+    "licenseId": "GFDL-1.3-no-invariants-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later - no invariants",
+    "licenseId": "GFDL-1.3-no-invariants-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only",
+    "licenseId": "GFDL-1.3-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later",
+    "licenseId": "GFDL-1.3-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "Giftware License",
+    "licenseId": "Giftware",
+    "deprecated": false
+  },
+  {
+    "name": "GL2PS License",
+    "licenseId": "GL2PS",
+    "deprecated": false
+  },
+  {
+    "name": "3dfx Glide License",
+    "licenseId": "Glide",
+    "deprecated": false
+  },
+  {
+    "name": "Glulxe License",
+    "licenseId": "Glulxe",
+    "deprecated": false
+  },
+  {
+    "name": "Good Luck With That Public License",
+    "licenseId": "GLWTPL",
+    "deprecated": false
+  },
+  {
+    "name": "gnuplot License",
+    "licenseId": "gnuplot",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v1.0 only",
+    "licenseId": "GPL-1.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v1.0 only",
+    "licenseId": "GPL-1.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v1.0 or later",
+    "licenseId": "GPL-1.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v1.0 or later",
+    "licenseId": "GPL-1.0+",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 only",
+    "licenseId": "GPL-2.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 only",
+    "licenseId": "GPL-2.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v2.0 or later",
+    "licenseId": "GPL-2.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Autoconf exception",
+    "licenseId": "GPL-2.0-with-autoconf-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Bison exception",
+    "licenseId": "GPL-2.0-with-bison-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Classpath exception",
+    "licenseId": "GPL-2.0-with-classpath-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Font exception",
+    "licenseId": "GPL-2.0-with-font-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+    "licenseId": "GPL-2.0-with-GCC-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v2.0 or later",
+    "licenseId": "GPL-2.0+",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v3.0 only",
+    "licenseId": "GPL-3.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v3.0 only",
+    "licenseId": "GPL-3.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v3.0 or later",
+    "licenseId": "GPL-3.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU General Public License v3.0 w/Autoconf exception",
+    "licenseId": "GPL-3.0-with-autoconf-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+    "licenseId": "GPL-3.0-with-GCC-exception",
+    "deprecated": true
+  },
+  {
+    "name": "GNU General Public License v3.0 or later",
+    "licenseId": "GPL-3.0+",
+    "deprecated": true
+  },
+  {
+    "name": "Graphics Gems License",
+    "licenseId": "Graphics-Gems",
+    "deprecated": false
+  },
+  {
+    "name": "gSOAP Public License v1.3b",
+    "licenseId": "gSOAP-1.3b",
+    "deprecated": false
+  },
+  {
+    "name": "gtkbook License",
+    "licenseId": "gtkbook",
+    "deprecated": false
+  },
+  {
+    "name": "Gutmann License",
+    "licenseId": "Gutmann",
+    "deprecated": false
+  },
+  {
+    "name": "Haskell Language Report License",
+    "licenseId": "HaskellReport",
+    "deprecated": false
+  },
+  {
+    "name": "HDF5 License",
+    "licenseId": "HDF5",
+    "deprecated": false
+  },
+  {
+    "name": "hdparm License",
+    "licenseId": "hdparm",
+    "deprecated": false
+  },
+  {
+    "name": "HIDAPI License",
+    "licenseId": "HIDAPI",
+    "deprecated": false
+  },
+  {
+    "name": "Hippocratic License 2.1",
+    "licenseId": "Hippocratic-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Hewlett-Packard 1986 License",
+    "licenseId": "HP-1986",
+    "deprecated": false
+  },
+  {
+    "name": "Hewlett-Packard 1989 License",
+    "licenseId": "HP-1989",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer",
+    "licenseId": "HPND",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - DEC variant",
+    "licenseId": "HPND-DEC",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - documentation variant",
+    "licenseId": "HPND-doc",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
+    "licenseId": "HPND-doc-sell",
+    "deprecated": false
+  },
+  {
+    "name": "HPND with US Government export control warning",
+    "licenseId": "HPND-export-US",
+    "deprecated": false
+  },
+  {
+    "name": "HPND with US Government export control warning and acknowledgment",
+    "licenseId": "HPND-export-US-acknowledgement",
+    "deprecated": false
+  },
+  {
+    "name": "HPND with US Government export control warning and modification rqmt",
+    "licenseId": "HPND-export-US-modify",
+    "deprecated": false
+  },
+  {
+    "name": "HPND with US Government export control and 2 disclaimers",
+    "licenseId": "HPND-export2-US",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
+    "licenseId": "HPND-Fenneberg-Livingston",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
+    "licenseId": "HPND-INRIA-IMAG",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Intel variant",
+    "licenseId": "HPND-Intel",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
+    "licenseId": "HPND-Kevlin-Henney",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+    "licenseId": "HPND-Markus-Kuhn",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - merchantability variant",
+    "licenseId": "HPND-merchantability-variant",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
+    "licenseId": "HPND-MIT-disclaimer",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Netrek variant",
+    "licenseId": "HPND-Netrek",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
+    "licenseId": "HPND-Pbmplus",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+    "licenseId": "HPND-sell-MIT-disclaimer-xserver",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
+    "licenseId": "HPND-sell-regexpr",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell variant",
+    "licenseId": "HPND-sell-variant",
+    "deprecated": false
+  },
+  {
+    "name": "HPND sell variant with MIT disclaimer",
+    "licenseId": "HPND-sell-variant-MIT-disclaimer",
+    "deprecated": false
+  },
+  {
+    "name": "HPND sell variant with MIT disclaimer - reverse",
+    "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - University of California variant",
+    "licenseId": "HPND-UC",
+    "deprecated": false
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
+    "licenseId": "HPND-UC-export-US",
+    "deprecated": false
+  },
+  {
+    "name": "HTML Tidy License",
+    "licenseId": "HTMLTIDY",
+    "deprecated": false
+  },
+  {
+    "name": "IBM PowerPC Initialization and Boot Software",
+    "licenseId": "IBM-pibs",
+    "deprecated": false
+  },
+  {
+    "name": "ICU License",
+    "licenseId": "ICU",
+    "deprecated": false
+  },
+  {
+    "name": "IEC    Code Components End-user licence agreement",
+    "licenseId": "IEC-Code-Components-EULA",
+    "deprecated": false
+  },
+  {
+    "name": "Independent JPEG Group License",
+    "licenseId": "IJG",
+    "deprecated": false
+  },
+  {
+    "name": "Independent JPEG Group License - short",
+    "licenseId": "IJG-short",
+    "deprecated": false
+  },
+  {
+    "name": "ImageMagick License",
+    "licenseId": "ImageMagick",
+    "deprecated": false
+  },
+  {
+    "name": "iMatix Standard Function Library Agreement",
+    "licenseId": "iMatix",
+    "deprecated": false
+  },
+  {
+    "name": "Imlib2 License",
+    "licenseId": "Imlib2",
+    "deprecated": false
+  },
+  {
+    "name": "Info-ZIP License",
+    "licenseId": "Info-ZIP",
+    "deprecated": false
+  },
+  {
+    "name": "Inner Net License v2.0",
+    "licenseId": "Inner-Net-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Inno Setup License",
+    "licenseId": "InnoSetup",
+    "deprecated": false
+  },
+  {
+    "name": "Intel Open Source License",
+    "licenseId": "Intel",
+    "deprecated": false
+  },
+  {
+    "name": "Intel ACPI Software License Agreement",
+    "licenseId": "Intel-ACPI",
+    "deprecated": false
+  },
+  {
+    "name": "Interbase Public License v1.0",
+    "licenseId": "Interbase-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "IPA Font License",
+    "licenseId": "IPA",
+    "deprecated": false
+  },
+  {
+    "name": "IBM Public License v1.0",
+    "licenseId": "IPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "ISC License",
+    "licenseId": "ISC",
+    "deprecated": false
+  },
+  {
+    "name": "ISC Veillard variant",
+    "licenseId": "ISC-Veillard",
+    "deprecated": false
+  },
+  {
+    "name": "Jam License",
+    "licenseId": "Jam",
+    "deprecated": false
+  },
+  {
+    "name": "JasPer License",
+    "licenseId": "JasPer-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Jove License",
+    "licenseId": "jove",
+    "deprecated": false
+  },
+  {
+    "name": "JPL Image Use Policy",
+    "licenseId": "JPL-image",
+    "deprecated": false
+  },
+  {
+    "name": "Japan Network Information Center License",
+    "licenseId": "JPNIC",
+    "deprecated": false
+  },
+  {
+    "name": "JSON License",
+    "licenseId": "JSON",
+    "deprecated": false
+  },
+  {
+    "name": "Kastrup License",
+    "licenseId": "Kastrup",
+    "deprecated": false
+  },
+  {
+    "name": "Kazlib License",
+    "licenseId": "Kazlib",
+    "deprecated": false
+  },
+  {
+    "name": "Knuth CTAN License",
+    "licenseId": "Knuth-CTAN",
+    "deprecated": false
+  },
+  {
+    "name": "Licence Art Libre 1.2",
+    "licenseId": "LAL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "Licence Art Libre 1.3",
+    "licenseId": "LAL-1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Latex2e License",
+    "licenseId": "Latex2e",
+    "deprecated": false
+  },
+  {
+    "name": "Latex2e with translated notice permission",
+    "licenseId": "Latex2e-translated-notice",
+    "deprecated": false
+  },
+  {
+    "name": "Leptonica License",
+    "licenseId": "Leptonica",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Library General Public License v2 only",
+    "licenseId": "LGPL-2.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Library General Public License v2 only",
+    "licenseId": "LGPL-2.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Library General Public License v2 or later",
+    "licenseId": "LGPL-2.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Library General Public License v2 or later",
+    "licenseId": "LGPL-2.0+",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 only",
+    "licenseId": "LGPL-2.1",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 only",
+    "licenseId": "LGPL-2.1-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 or later",
+    "licenseId": "LGPL-2.1-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 or later",
+    "licenseId": "LGPL-2.1+",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 only",
+    "licenseId": "LGPL-3.0",
+    "deprecated": true
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 only",
+    "licenseId": "LGPL-3.0-only",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 or later",
+    "licenseId": "LGPL-3.0-or-later",
+    "deprecated": false
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 or later",
+    "licenseId": "LGPL-3.0+",
+    "deprecated": true
+  },
+  {
+    "name": "Lesser General Public License For Linguistic Resources",
+    "licenseId": "LGPLLR",
+    "deprecated": false
+  },
+  {
+    "name": "libpng License",
+    "licenseId": "Libpng",
+    "deprecated": false
+  },
+  {
+    "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35",
+    "licenseId": "libpng-1.6.35",
+    "deprecated": false
+  },
+  {
+    "name": "PNG Reference Library version 2",
+    "licenseId": "libpng-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "libselinux public domain notice",
+    "licenseId": "libselinux-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "libtiff License",
+    "licenseId": "libtiff",
+    "deprecated": false
+  },
+  {
+    "name": "libutil David Nugent License",
+    "licenseId": "libutil-David-Nugent",
+    "deprecated": false
+  },
+  {
+    "name": "Licence Libre du Qubec  Permissive version 1.1",
+    "licenseId": "LiLiQ-P-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Licence Libre du Qubec  Rciprocit version 1.1",
+    "licenseId": "LiLiQ-R-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Licence Libre du Qubec  Rciprocit forte version 1.1",
+    "licenseId": "LiLiQ-Rplus-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Linux man-pages - 1 paragraph",
+    "licenseId": "Linux-man-pages-1-para",
+    "deprecated": false
+  },
+  {
+    "name": "Linux man-pages Copyleft",
+    "licenseId": "Linux-man-pages-copyleft",
+    "deprecated": false
+  },
+  {
+    "name": "Linux man-pages Copyleft - 2 paragraphs",
+    "licenseId": "Linux-man-pages-copyleft-2-para",
+    "deprecated": false
+  },
+  {
+    "name": "Linux man-pages Copyleft Variant",
+    "licenseId": "Linux-man-pages-copyleft-var",
+    "deprecated": false
+  },
+  {
+    "name": "Linux Kernel Variant of OpenIB.org license",
+    "licenseId": "Linux-OpenIB",
+    "deprecated": false
+  },
+  {
+    "name": "Common Lisp LOOP License",
+    "licenseId": "LOOP",
+    "deprecated": false
+  },
+  {
+    "name": "LPD Documentation License",
+    "licenseId": "LPD-document",
+    "deprecated": false
+  },
+  {
+    "name": "Lucent Public License Version 1.0",
+    "licenseId": "LPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Lucent Public License v1.02",
+    "licenseId": "LPL-1.02",
+    "deprecated": false
+  },
+  {
+    "name": "LaTeX Project Public License v1.0",
+    "licenseId": "LPPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "LaTeX Project Public License v1.1",
+    "licenseId": "LPPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "LaTeX Project Public License v1.2",
+    "licenseId": "LPPL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "LaTeX Project Public License v1.3a",
+    "licenseId": "LPPL-1.3a",
+    "deprecated": false
+  },
+  {
+    "name": "LaTeX Project Public License v1.3c",
+    "licenseId": "LPPL-1.3c",
+    "deprecated": false
+  },
+  {
+    "name": "lsof License",
+    "licenseId": "lsof",
+    "deprecated": false
+  },
+  {
+    "name": "Lucida Bitmap Fonts License",
+    "licenseId": "Lucida-Bitmap-Fonts",
+    "deprecated": false
+  },
+  {
+    "name": "LZMA SDK License (versions 9.11 to 9.20)",
+    "licenseId": "LZMA-SDK-9.11-to-9.20",
+    "deprecated": false
+  },
+  {
+    "name": "LZMA SDK License (versions 9.22 and beyond)",
+    "licenseId": "LZMA-SDK-9.22",
+    "deprecated": false
+  },
+  {
+    "name": "Mackerras 3-Clause License",
+    "licenseId": "Mackerras-3-Clause",
+    "deprecated": false
+  },
+  {
+    "name": "Mackerras 3-Clause - acknowledgment variant",
+    "licenseId": "Mackerras-3-Clause-acknowledgment",
+    "deprecated": false
+  },
+  {
+    "name": "magaz License",
+    "licenseId": "magaz",
+    "deprecated": false
+  },
+  {
+    "name": "mailprio License",
+    "licenseId": "mailprio",
+    "deprecated": false
+  },
+  {
+    "name": "MakeIndex License",
+    "licenseId": "MakeIndex",
+    "deprecated": false
+  },
+  {
+    "name": "man2html License",
+    "licenseId": "man2html",
+    "deprecated": false
+  },
+  {
+    "name": "Martin Birgmeier License",
+    "licenseId": "Martin-Birgmeier",
+    "deprecated": false
+  },
+  {
+    "name": "McPhee Slideshow License",
+    "licenseId": "McPhee-slideshow",
+    "deprecated": false
+  },
+  {
+    "name": "metamail License",
+    "licenseId": "metamail",
+    "deprecated": false
+  },
+  {
+    "name": "Minpack License",
+    "licenseId": "Minpack",
+    "deprecated": false
+  },
+  {
+    "name": "MIPS License",
+    "licenseId": "MIPS",
+    "deprecated": false
+  },
+  {
+    "name": "The MirOS Licence",
+    "licenseId": "MirOS",
+    "deprecated": false
+  },
+  {
+    "name": "MIT License",
+    "licenseId": "MIT",
+    "deprecated": false
+  },
+  {
+    "name": "MIT No Attribution",
+    "licenseId": "MIT-0",
+    "deprecated": false
+  },
+  {
+    "name": "Enlightenment License (e16)",
+    "licenseId": "MIT-advertising",
+    "deprecated": false
+  },
+  {
+    "name": "MIT Click License",
+    "licenseId": "MIT-Click",
+    "deprecated": false
+  },
+  {
+    "name": "CMU License",
+    "licenseId": "MIT-CMU",
+    "deprecated": false
+  },
+  {
+    "name": "enna License",
+    "licenseId": "MIT-enna",
+    "deprecated": false
+  },
+  {
+    "name": "feh License",
+    "licenseId": "MIT-feh",
+    "deprecated": false
+  },
+  {
+    "name": "MIT Festival Variant",
+    "licenseId": "MIT-Festival",
+    "deprecated": false
+  },
+  {
+    "name": "MIT Khronos - old variant",
+    "licenseId": "MIT-Khronos-old",
+    "deprecated": false
+  },
+  {
+    "name": "MIT License Modern Variant",
+    "licenseId": "MIT-Modern-Variant",
+    "deprecated": false
+  },
+  {
+    "name": "MIT Open Group variant",
+    "licenseId": "MIT-open-group",
+    "deprecated": false
+  },
+  {
+    "name": "MIT testregex Variant",
+    "licenseId": "MIT-testregex",
+    "deprecated": false
+  },
+  {
+    "name": "MIT Tom Wu Variant",
+    "licenseId": "MIT-Wu",
+    "deprecated": false
+  },
+  {
+    "name": "MIT +no-false-attribs license",
+    "licenseId": "MITNFA",
+    "deprecated": false
+  },
+  {
+    "name": "MMIXware License",
+    "licenseId": "MMIXware",
+    "deprecated": false
+  },
+  {
+    "name": "Motosoto License",
+    "licenseId": "Motosoto",
+    "deprecated": false
+  },
+  {
+    "name": "MPEG Software Simulation",
+    "licenseId": "MPEG-SSG",
+    "deprecated": false
+  },
+  {
+    "name": "mpi Permissive License",
+    "licenseId": "mpi-permissive",
+    "deprecated": false
+  },
+  {
+    "name": "mpich2 License",
+    "licenseId": "mpich2",
+    "deprecated": false
+  },
+  {
+    "name": "Mozilla Public License 1.0",
+    "licenseId": "MPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Mozilla Public License 1.1",
+    "licenseId": "MPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Mozilla Public License 2.0",
+    "licenseId": "MPL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Mozilla Public License 2.0 (no copyleft exception)",
+    "licenseId": "MPL-2.0-no-copyleft-exception",
+    "deprecated": false
+  },
+  {
+    "name": "mplus Font License",
+    "licenseId": "mplus",
+    "deprecated": false
+  },
+  {
+    "name": "Microsoft Limited Public License",
+    "licenseId": "MS-LPL",
+    "deprecated": false
+  },
+  {
+    "name": "Microsoft Public License",
+    "licenseId": "MS-PL",
+    "deprecated": false
+  },
+  {
+    "name": "Microsoft Reciprocal License",
+    "licenseId": "MS-RL",
+    "deprecated": false
+  },
+  {
+    "name": "Matrix Template Library License",
+    "licenseId": "MTLL",
+    "deprecated": false
+  },
+  {
+    "name": "Mulan Permissive Software License, Version 1",
+    "licenseId": "MulanPSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Mulan Permissive Software License, Version 2",
+    "licenseId": "MulanPSL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Multics License",
+    "licenseId": "Multics",
+    "deprecated": false
+  },
+  {
+    "name": "Mup License",
+    "licenseId": "Mup",
+    "deprecated": false
+  },
+  {
+    "name": "Nara Institute of Science and Technology License (2003)",
+    "licenseId": "NAIST-2003",
+    "deprecated": false
+  },
+  {
+    "name": "NASA Open Source Agreement 1.3",
+    "licenseId": "NASA-1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Naumen Public License",
+    "licenseId": "Naumen",
+    "deprecated": false
+  },
+  {
+    "name": "Net Boolean Public License v1",
+    "licenseId": "NBPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "NCBI Public Domain Notice",
+    "licenseId": "NCBI-PD",
+    "deprecated": false
+  },
+  {
+    "name": "Non-Commercial Government Licence",
+    "licenseId": "NCGL-UK-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "NCL Source Code License",
+    "licenseId": "NCL",
+    "deprecated": false
+  },
+  {
+    "name": "University of Illinois/NCSA Open Source License",
+    "licenseId": "NCSA",
+    "deprecated": false
+  },
+  {
+    "name": "Net-SNMP License",
+    "licenseId": "Net-SNMP",
+    "deprecated": true
+  },
+  {
+    "name": "NetCDF license",
+    "licenseId": "NetCDF",
+    "deprecated": false
+  },
+  {
+    "name": "Newsletr License",
+    "licenseId": "Newsletr",
+    "deprecated": false
+  },
+  {
+    "name": "Nethack General Public License",
+    "licenseId": "NGPL",
+    "deprecated": false
+  },
+  {
+    "name": "ngrep License",
+    "licenseId": "ngrep",
+    "deprecated": false
+  },
+  {
+    "name": "NICTA Public Software License, Version 1.0",
+    "licenseId": "NICTA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "NIST Public Domain Notice",
+    "licenseId": "NIST-PD",
+    "deprecated": false
+  },
+  {
+    "name": "NIST Public Domain Notice with license fallback",
+    "licenseId": "NIST-PD-fallback",
+    "deprecated": false
+  },
+  {
+    "name": "NIST Software License",
+    "licenseId": "NIST-Software",
+    "deprecated": false
+  },
+  {
+    "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
+    "licenseId": "NLOD-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
+    "licenseId": "NLOD-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "No Limit Public License",
+    "licenseId": "NLPL",
+    "deprecated": false
+  },
+  {
+    "name": "Nokia Open Source License",
+    "licenseId": "Nokia",
+    "deprecated": false
+  },
+  {
+    "name": "Netizen Open Source License",
+    "licenseId": "NOSL",
+    "deprecated": false
+  },
+  {
+    "name": "Noweb License",
+    "licenseId": "Noweb",
+    "deprecated": false
+  },
+  {
+    "name": "Netscape Public License v1.0",
+    "licenseId": "NPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Netscape Public License v1.1",
+    "licenseId": "NPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Non-Profit Open Software License 3.0",
+    "licenseId": "NPOSL-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "NRL License",
+    "licenseId": "NRL",
+    "deprecated": false
+  },
+  {
+    "name": "NTIA Public Domain Notice",
+    "licenseId": "NTIA-PD",
+    "deprecated": false
+  },
+  {
+    "name": "NTP License",
+    "licenseId": "NTP",
+    "deprecated": false
+  },
+  {
+    "name": "NTP No Attribution",
+    "licenseId": "NTP-0",
+    "deprecated": false
+  },
+  {
+    "name": "Nunit License",
+    "licenseId": "Nunit",
+    "deprecated": true
+  },
+  {
+    "name": "Open Use of Data Agreement v1.0",
+    "licenseId": "O-UDA-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "OAR License",
+    "licenseId": "OAR",
+    "deprecated": false
+  },
+  {
+    "name": "Open CASCADE Technology Public License",
+    "licenseId": "OCCT-PL",
+    "deprecated": false
+  },
+  {
+    "name": "OCLC Research Public License 2.0",
+    "licenseId": "OCLC-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Data Commons Open Database License v1.0",
+    "licenseId": "ODbL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Data Commons Attribution License v1.0",
+    "licenseId": "ODC-By-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "OFFIS License",
+    "licenseId": "OFFIS",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.0",
+    "licenseId": "OFL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+    "licenseId": "OFL-1.0-no-RFN",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.0 with Reserved Font Name",
+    "licenseId": "OFL-1.0-RFN",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.1",
+    "licenseId": "OFL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+    "licenseId": "OFL-1.1-no-RFN",
+    "deprecated": false
+  },
+  {
+    "name": "SIL Open Font License 1.1 with Reserved Font Name",
+    "licenseId": "OFL-1.1-RFN",
+    "deprecated": false
+  },
+  {
+    "name": "OGC Software License, Version 1.0",
+    "licenseId": "OGC-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Taiwan Open Government Data License, version 1.0",
+    "licenseId": "OGDL-Taiwan-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Government Licence - Canada",
+    "licenseId": "OGL-Canada-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Government Licence v1.0",
+    "licenseId": "OGL-UK-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Government Licence v2.0",
+    "licenseId": "OGL-UK-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Government Licence v3.0",
+    "licenseId": "OGL-UK-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Group Test Suite License",
+    "licenseId": "OGTSL",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v1.1",
+    "licenseId": "OLDAP-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v1.2",
+    "licenseId": "OLDAP-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v1.3",
+    "licenseId": "OLDAP-1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v1.4",
+    "licenseId": "OLDAP-1.4",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+    "licenseId": "OLDAP-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.0.1",
+    "licenseId": "OLDAP-2.0.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.1",
+    "licenseId": "OLDAP-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.2",
+    "licenseId": "OLDAP-2.2",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.2.1",
+    "licenseId": "OLDAP-2.2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License 2.2.2",
+    "licenseId": "OLDAP-2.2.2",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.3",
+    "licenseId": "OLDAP-2.3",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.4",
+    "licenseId": "OLDAP-2.4",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.5",
+    "licenseId": "OLDAP-2.5",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.6",
+    "licenseId": "OLDAP-2.6",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.7",
+    "licenseId": "OLDAP-2.7",
+    "deprecated": false
+  },
+  {
+    "name": "Open LDAP Public License v2.8",
+    "licenseId": "OLDAP-2.8",
+    "deprecated": false
+  },
+  {
+    "name": "Open Logistics Foundation License Version 1.3",
+    "licenseId": "OLFL-1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Open Market License",
+    "licenseId": "OML",
+    "deprecated": false
+  },
+  {
+    "name": "OpenPBS v2.3 Software License",
+    "licenseId": "OpenPBS-2.3",
+    "deprecated": false
+  },
+  {
+    "name": "OpenSSL License",
+    "licenseId": "OpenSSL",
+    "deprecated": false
+  },
+  {
+    "name": "OpenSSL License - standalone",
+    "licenseId": "OpenSSL-standalone",
+    "deprecated": false
+  },
+  {
+    "name": "OpenVision License",
+    "licenseId": "OpenVision",
+    "deprecated": false
+  },
+  {
+    "name": "Open Public License v1.0",
+    "licenseId": "OPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "United    Kingdom Open Parliament Licence v3.0",
+    "licenseId": "OPL-UK-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Publication License v1.0",
+    "licenseId": "OPUBL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "OSET Public License version 2.1",
+    "licenseId": "OSET-PL-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open Software License 1.0",
+    "licenseId": "OSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Software License 1.1",
+    "licenseId": "OSL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open Software License 2.0",
+    "licenseId": "OSL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Software License 2.1",
+    "licenseId": "OSL-2.1",
+    "deprecated": false
+  },
+  {
+    "name": "Open Software License 3.0",
+    "licenseId": "OSL-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "PADL License",
+    "licenseId": "PADL",
+    "deprecated": false
+  },
+  {
+    "name": "The Parity Public License 6.0.0",
+    "licenseId": "Parity-6.0.0",
+    "deprecated": false
+  },
+  {
+    "name": "The Parity Public License 7.0.0",
+    "licenseId": "Parity-7.0.0",
+    "deprecated": false
+  },
+  {
+    "name": "Open Data Commons Public Domain Dedication & License 1.0",
+    "licenseId": "PDDL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "PHP License v3.0",
+    "licenseId": "PHP-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "PHP License v3.01",
+    "licenseId": "PHP-3.01",
+    "deprecated": false
+  },
+  {
+    "name": "Pixar License",
+    "licenseId": "Pixar",
+    "deprecated": false
+  },
+  {
+    "name": "pkgconf License",
+    "licenseId": "pkgconf",
+    "deprecated": false
+  },
+  {
+    "name": "Plexus Classworlds License",
+    "licenseId": "Plexus",
+    "deprecated": false
+  },
+  {
+    "name": "pnmstitch License",
+    "licenseId": "pnmstitch",
+    "deprecated": false
+  },
+  {
+    "name": "PolyForm Noncommercial License 1.0.0",
+    "licenseId": "PolyForm-Noncommercial-1.0.0",
+    "deprecated": false
+  },
+  {
+    "name": "PolyForm Small Business License 1.0.0",
+    "licenseId": "PolyForm-Small-Business-1.0.0",
+    "deprecated": false
+  },
+  {
+    "name": "PostgreSQL License",
+    "licenseId": "PostgreSQL",
+    "deprecated": false
+  },
+  {
+    "name": "Peer Production License",
+    "licenseId": "PPL",
+    "deprecated": false
+  },
+  {
+    "name": "Python Software Foundation License 2.0",
+    "licenseId": "PSF-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "psfrag License",
+    "licenseId": "psfrag",
+    "deprecated": false
+  },
+  {
+    "name": "psutils License",
+    "licenseId": "psutils",
+    "deprecated": false
+  },
+  {
+    "name": "Python License 2.0",
+    "licenseId": "Python-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Python License 2.0.1",
+    "licenseId": "Python-2.0.1",
+    "deprecated": false
+  },
+  {
+    "name": "Python ldap License",
+    "licenseId": "python-ldap",
+    "deprecated": false
+  },
+  {
+    "name": "Qhull License",
+    "licenseId": "Qhull",
+    "deprecated": false
+  },
+  {
+    "name": "Q Public License 1.0",
+    "licenseId": "QPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Q Public License 1.0 - INRIA 2004 variant",
+    "licenseId": "QPL-1.0-INRIA-2004",
+    "deprecated": false
+  },
+  {
+    "name": "radvd License",
+    "licenseId": "radvd",
+    "deprecated": false
+  },
+  {
+    "name": "Rdisc License",
+    "licenseId": "Rdisc",
+    "deprecated": false
+  },
+  {
+    "name": "Red Hat eCos Public License v1.1",
+    "licenseId": "RHeCos-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Reciprocal Public License 1.1",
+    "licenseId": "RPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Reciprocal Public License 1.5",
+    "licenseId": "RPL-1.5",
+    "deprecated": false
+  },
+  {
+    "name": "RealNetworks Public Source License v1.0",
+    "licenseId": "RPSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "RSA Message-Digest License",
+    "licenseId": "RSA-MD",
+    "deprecated": false
+  },
+  {
+    "name": "Ricoh Source Code Public License",
+    "licenseId": "RSCPL",
+    "deprecated": false
+  },
+  {
+    "name": "Ruby License",
+    "licenseId": "Ruby",
+    "deprecated": false
+  },
+  {
+    "name": "Ruby pty extension license",
+    "licenseId": "Ruby-pty",
+    "deprecated": false
+  },
+  {
+    "name": "Sax Public Domain Notice",
+    "licenseId": "SAX-PD",
+    "deprecated": false
+  },
+  {
+    "name": "Sax Public Domain Notice 2.0",
+    "licenseId": "SAX-PD-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Saxpath License",
+    "licenseId": "Saxpath",
+    "deprecated": false
+  },
+  {
+    "name": "SCEA Shared Source License",
+    "licenseId": "SCEA",
+    "deprecated": false
+  },
+  {
+    "name": "Scheme Language Report License",
+    "licenseId": "SchemeReport",
+    "deprecated": false
+  },
+  {
+    "name": "Sendmail License",
+    "licenseId": "Sendmail",
+    "deprecated": false
+  },
+  {
+    "name": "Sendmail License 8.23",
+    "licenseId": "Sendmail-8.23",
+    "deprecated": false
+  },
+  {
+    "name": "Sendmail Open Source License v1.1",
+    "licenseId": "Sendmail-Open-Source-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "SGI Free Software License B v1.0",
+    "licenseId": "SGI-B-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "SGI Free Software License B v1.1",
+    "licenseId": "SGI-B-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "SGI Free Software License B v2.0",
+    "licenseId": "SGI-B-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "SGI OpenGL License",
+    "licenseId": "SGI-OpenGL",
+    "deprecated": false
+  },
+  {
+    "name": "SGP4 Permission Notice",
+    "licenseId": "SGP4",
+    "deprecated": false
+  },
+  {
+    "name": "Solderpad Hardware License v0.5",
+    "licenseId": "SHL-0.5",
+    "deprecated": false
+  },
+  {
+    "name": "Solderpad Hardware License, Version 0.51",
+    "licenseId": "SHL-0.51",
+    "deprecated": false
+  },
+  {
+    "name": "Simple Public License 2.0",
+    "licenseId": "SimPL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Sun Industry Standards Source License v1.1",
+    "licenseId": "SISSL",
+    "deprecated": false
+  },
+  {
+    "name": "Sun Industry Standards Source License v1.2",
+    "licenseId": "SISSL-1.2",
+    "deprecated": false
+  },
+  {
+    "name": "SL License",
+    "licenseId": "SL",
+    "deprecated": false
+  },
+  {
+    "name": "Sleepycat License",
+    "licenseId": "Sleepycat",
+    "deprecated": false
+  },
+  {
+    "name": "SMAIL General Public License",
+    "licenseId": "SMAIL-GPL",
+    "deprecated": false
+  },
+  {
+    "name": "Standard ML of New Jersey License",
+    "licenseId": "SMLNJ",
+    "deprecated": false
+  },
+  {
+    "name": "Secure Messaging Protocol Public License",
+    "licenseId": "SMPPL",
+    "deprecated": false
+  },
+  {
+    "name": "SNIA Public License 1.1",
+    "licenseId": "SNIA",
+    "deprecated": false
+  },
+  {
+    "name": "snprintf License",
+    "licenseId": "snprintf",
+    "deprecated": false
+  },
+  {
+    "name": "SOFA Software License",
+    "licenseId": "SOFA",
+    "deprecated": false
+  },
+  {
+    "name": "softSurfer License",
+    "licenseId": "softSurfer",
+    "deprecated": false
+  },
+  {
+    "name": "Soundex License",
+    "licenseId": "Soundex",
+    "deprecated": false
+  },
+  {
+    "name": "Spencer License 86",
+    "licenseId": "Spencer-86",
+    "deprecated": false
+  },
+  {
+    "name": "Spencer License 94",
+    "licenseId": "Spencer-94",
+    "deprecated": false
+  },
+  {
+    "name": "Spencer License 99",
+    "licenseId": "Spencer-99",
+    "deprecated": false
+  },
+  {
+    "name": "Sun Public License v1.0",
+    "licenseId": "SPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "ssh-keyscan License",
+    "licenseId": "ssh-keyscan",
+    "deprecated": false
+  },
+  {
+    "name": "SSH OpenSSH license",
+    "licenseId": "SSH-OpenSSH",
+    "deprecated": false
+  },
+  {
+    "name": "SSH short notice",
+    "licenseId": "SSH-short",
+    "deprecated": false
+  },
+  {
+    "name": "SSLeay License - standalone",
+    "licenseId": "SSLeay-standalone",
+    "deprecated": false
+  },
+  {
+    "name": "Server Side Public License, v 1",
+    "licenseId": "SSPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Standard ML of New Jersey License",
+    "licenseId": "StandardML-NJ",
+    "deprecated": true
+  },
+  {
+    "name": "SugarCRM Public License v1.1.3",
+    "licenseId": "SugarCRM-1.1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Sun PPP License",
+    "licenseId": "Sun-PPP",
+    "deprecated": false
+  },
+  {
+    "name": "Sun PPP License (2000)",
+    "licenseId": "Sun-PPP-2000",
+    "deprecated": false
+  },
+  {
+    "name": "SunPro License",
+    "licenseId": "SunPro",
+    "deprecated": false
+  },
+  {
+    "name": "Scheme Widget Library (SWL) Software License Agreement",
+    "licenseId": "SWL",
+    "deprecated": false
+  },
+  {
+    "name": "swrule License",
+    "licenseId": "swrule",
+    "deprecated": false
+  },
+  {
+    "name": "Symlinks License",
+    "licenseId": "Symlinks",
+    "deprecated": false
+  },
+  {
+    "name": "TAPR Open Hardware License v1.0",
+    "licenseId": "TAPR-OHL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "TCL/TK License",
+    "licenseId": "TCL",
+    "deprecated": false
+  },
+  {
+    "name": "TCP Wrappers License",
+    "licenseId": "TCP-wrappers",
+    "deprecated": false
+  },
+  {
+    "name": "TermReadKey License",
+    "licenseId": "TermReadKey",
+    "deprecated": false
+  },
+  {
+    "name": "Transitive Grace Period Public Licence 1.0",
+    "licenseId": "TGPPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "ThirdEye License",
+    "licenseId": "ThirdEye",
+    "deprecated": false
+  },
+  {
+    "name": "threeparttable License",
+    "licenseId": "threeparttable",
+    "deprecated": false
+  },
+  {
+    "name": "TMate Open Source License",
+    "licenseId": "TMate",
+    "deprecated": false
+  },
+  {
+    "name": "TORQUE v2.5+ Software License v1.1",
+    "licenseId": "TORQUE-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Trusster Open Source License",
+    "licenseId": "TOSL",
+    "deprecated": false
+  },
+  {
+    "name": "Time::ParseDate License",
+    "licenseId": "TPDL",
+    "deprecated": false
+  },
+  {
+    "name": "THOR Public License 1.0",
+    "licenseId": "TPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "TrustedQSL License",
+    "licenseId": "TrustedQSL",
+    "deprecated": false
+  },
+  {
+    "name": "Text-Tabs+Wrap License",
+    "licenseId": "TTWL",
+    "deprecated": false
+  },
+  {
+    "name": "TTYP0 License",
+    "licenseId": "TTYP0",
+    "deprecated": false
+  },
+  {
+    "name": "Technische Universitaet Berlin License 1.0",
+    "licenseId": "TU-Berlin-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Technische Universitaet Berlin License 2.0",
+    "licenseId": "TU-Berlin-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Ubuntu Font Licence v1.0",
+    "licenseId": "Ubuntu-font-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "UCAR License",
+    "licenseId": "UCAR",
+    "deprecated": false
+  },
+  {
+    "name": "Upstream Compatibility License v1.0",
+    "licenseId": "UCL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "ulem License",
+    "licenseId": "ulem",
+    "deprecated": false
+  },
+  {
+    "name": "Michigan/Merit Networks License",
+    "licenseId": "UMich-Merit",
+    "deprecated": false
+  },
+  {
+    "name": "Unicode License v3",
+    "licenseId": "Unicode-3.0",
+    "deprecated": false
+  },
+  {
+    "name": "Unicode License Agreement - Data Files and Software (2015)",
+    "licenseId": "Unicode-DFS-2015",
+    "deprecated": false
+  },
+  {
+    "name": "Unicode License Agreement - Data Files and Software (2016)",
+    "licenseId": "Unicode-DFS-2016",
+    "deprecated": false
+  },
+  {
+    "name": "Unicode Terms of Use",
+    "licenseId": "Unicode-TOU",
+    "deprecated": false
+  },
+  {
+    "name": "UnixCrypt License",
+    "licenseId": "UnixCrypt",
+    "deprecated": false
+  },
+  {
+    "name": "The Unlicense",
+    "licenseId": "Unlicense",
+    "deprecated": false
+  },
+  {
+    "name": "Unlicense - libtelnet variant",
+    "licenseId": "Unlicense-libtelnet",
+    "deprecated": false
+  },
+  {
+    "name": "Unlicense - libwhirlpool variant",
+    "licenseId": "Unlicense-libwhirlpool",
+    "deprecated": false
+  },
+  {
+    "name": "Universal Permissive License v1.0",
+    "licenseId": "UPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Utah Raster Toolkit Run Length Encoded License",
+    "licenseId": "URT-RLE",
+    "deprecated": false
+  },
+  {
+    "name": "Vim License",
+    "licenseId": "Vim",
+    "deprecated": false
+  },
+  {
+    "name": "VOSTROM Public License for Open Source",
+    "licenseId": "VOSTROM",
+    "deprecated": false
+  },
+  {
+    "name": "Vovida Software License v1.0",
+    "licenseId": "VSL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "W3C Software Notice and License (2002-12-31)",
+    "licenseId": "W3C",
+    "deprecated": false
+  },
+  {
+    "name": "W3C Software Notice and License (1998-07-20)",
+    "licenseId": "W3C-19980720",
+    "deprecated": false
+  },
+  {
+    "name": "W3C Software Notice and Document License (2015-05-13)",
+    "licenseId": "W3C-20150513",
+    "deprecated": false
+  },
+  {
+    "name": "w3m License",
+    "licenseId": "w3m",
+    "deprecated": false
+  },
+  {
+    "name": "Sybase Open Watcom Public License 1.0",
+    "licenseId": "Watcom-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Widget Workshop License",
+    "licenseId": "Widget-Workshop",
+    "deprecated": false
+  },
+  {
+    "name": "Wsuipa License",
+    "licenseId": "Wsuipa",
+    "deprecated": false
+  },
+  {
+    "name": "Do What The F*ck You Want To Public License",
+    "licenseId": "WTFPL",
+    "deprecated": false
+  },
+  {
+    "name": "WWL License",
+    "licenseId": "wwl",
+    "deprecated": false
+  },
+  {
+    "name": "wxWindows Library License",
+    "licenseId": "wxWindows",
+    "deprecated": true
+  },
+  {
+    "name": "X11 License",
+    "licenseId": "X11",
+    "deprecated": false
+  },
+  {
+    "name": "X11 License Distribution Modification Variant",
+    "licenseId": "X11-distribute-modifications-variant",
+    "deprecated": false
+  },
+  {
+    "name": "X11 swapped final paragraphs",
+    "licenseId": "X11-swapped",
+    "deprecated": false
+  },
+  {
+    "name": "Xdebug License v 1.03",
+    "licenseId": "Xdebug-1.03",
+    "deprecated": false
+  },
+  {
+    "name": "Xerox License",
+    "licenseId": "Xerox",
+    "deprecated": false
+  },
+  {
+    "name": "Xfig License",
+    "licenseId": "Xfig",
+    "deprecated": false
+  },
+  {
+    "name": "XFree86 License 1.1",
+    "licenseId": "XFree86-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "xinetd License",
+    "licenseId": "xinetd",
+    "deprecated": false
+  },
+  {
+    "name": "xkeyboard-config Zinoviev License",
+    "licenseId": "xkeyboard-config-Zinoviev",
+    "deprecated": false
+  },
+  {
+    "name": "xlock License",
+    "licenseId": "xlock",
+    "deprecated": false
+  },
+  {
+    "name": "X.Net License",
+    "licenseId": "Xnet",
+    "deprecated": false
+  },
+  {
+    "name": "XPP License",
+    "licenseId": "xpp",
+    "deprecated": false
+  },
+  {
+    "name": "XSkat License",
+    "licenseId": "XSkat",
+    "deprecated": false
+  },
+  {
+    "name": "xzoom License",
+    "licenseId": "xzoom",
+    "deprecated": false
+  },
+  {
+    "name": "Yahoo! Public License v1.0",
+    "licenseId": "YPL-1.0",
+    "deprecated": false
+  },
+  {
+    "name": "Yahoo! Public License v1.1",
+    "licenseId": "YPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Zed License",
+    "licenseId": "Zed",
+    "deprecated": false
+  },
+  {
+    "name": "Zeeff License",
+    "licenseId": "Zeeff",
+    "deprecated": false
+  },
+  {
+    "name": "Zend License v2.0",
+    "licenseId": "Zend-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Zimbra Public License v1.3",
+    "licenseId": "Zimbra-1.3",
+    "deprecated": false
+  },
+  {
+    "name": "Zimbra Public License v1.4",
+    "licenseId": "Zimbra-1.4",
+    "deprecated": false
+  },
+  {
+    "name": "zlib License",
+    "licenseId": "Zlib",
+    "deprecated": false
+  },
+  {
+    "name": "zlib/libpng License with Acknowledgement",
+    "licenseId": "zlib-acknowledgement",
+    "deprecated": false
+  },
+  {
+    "name": "Zope Public License 1.1",
+    "licenseId": "ZPL-1.1",
+    "deprecated": false
+  },
+  {
+    "name": "Zope Public License 2.0",
+    "licenseId": "ZPL-2.0",
+    "deprecated": false
+  },
+  {
+    "name": "Zope Public License 2.1",
+    "licenseId": "ZPL-2.1",
+    "deprecated": false
+  }
+]

--- a/src/licenses/data.ts
+++ b/src/licenses/data.ts
@@ -1,36 +1,20 @@
-import licenses from '../codegen/licenses.json'
-import exceptions from '../codegen/exceptions.json'
-
+import licenses from "../codegen/licenses.json";
+import exceptions from "../codegen/exceptions.json";
 
 export type Exception = {
-    licenseExceptionId: string,
-    isDeprecatedLicenseId?: boolean,
-    name: string,
-    licenseComments?: string,
-    relatedLicenses?: string[]
-}
+    name: string;
+    licenseExceptionId: string;
+    deprecated: boolean;
+    relatedLicenses: string[];
+};
 
 export type License = {
-    licenseId: string,
-    isDeprecatedLicenseId?: boolean,
-    name: string,
-    isOsiApproved?: boolean,
-    seeAlso: string[]
-}
+    name: string;
+    licenseId: string;
+    deprecated: boolean;
+};
 
-export type Licenses = {
-    licenseListVersion: string,
-    releaseDate: string,
-    licenses: License[]
-}
+const licenseList = licenses as License[];
+const exceptionList = exceptions as Exception[];
 
-export type Exceptions = {
-    licenseListVersion: string,
-    releaseDate: string,
-    exceptions: Exception[]
-}
-
-const licenseList = licenses as Licenses
-const exceptionList = exceptions as Exceptions
-
-export { licenseList as licenses, exceptionList as exceptions }
+export { licenseList as licenses, exceptionList as exceptions };

--- a/src/licenses/index.ts
+++ b/src/licenses/index.ts
@@ -1,248 +1,256 @@
-import spdxCorrect from 'spdx-correct'
+import spdxCorrect from "spdx-correct";
 
-import { permutationsOf } from '../utils/permutations'
-import { LicenseInfo } from '../parser/types'
-import { licenses, Licenses, License, exceptions, Exceptions, Exception } from './data'
-export { licenses, Licenses, License, exceptions, Exceptions, Exception }
-
+import { permutationsOf } from "../utils/permutations";
+import { LicenseInfo } from "../parser/types";
+import { licenses, License, exceptions, Exception } from "./data";
+export { licenses, License, exceptions, Exception };
 
 type MapOfIds = {
-    get: (id: string) => string | undefined,
-    list: () => string[]
-}
+    get: (id: string) => string | undefined;
+    list: () => string[];
+};
 
 const idEndsWithVersionNumber = (id: string): boolean => {
-    return !!id.match(/^.*\d+(\.\d+)*$/)
-}
+    return !!id.match(/^.*\d+(\.\d+)*$/);
+};
 
 const removeVersionNumberFromId = (id: string): string => {
-    return idEndsWithVersionNumber(id) ? id.replace(/(v|\-)?\d+(\.\d+)*$/, '') : id
-}
+    return idEndsWithVersionNumber(id) ? id.replace(/(v|\-)?\d+(\.\d+)*$/, "") : id;
+};
 
 const countVersionsOf = (ids: string[], id: string): number => {
-    let prefix = removeVersionNumberFromId(id)
-    return ids.filter(candidateId => candidateId.startsWith(prefix)).length
-}
+    let prefix = removeVersionNumberFromId(id);
+    return ids.filter((candidateId) => candidateId.startsWith(prefix)).length;
+};
 
 const createMapOfIds = (ids: string[]): MapOfIds => {
-    const mutilateId = (id: string): string => id.toUpperCase().replace(/[^0-9a-zA-Z\+]/g, '')
-    const listOfOfficialIds: string[] = ids
-    const mapOfLowercaseIds: Map<string, string> = new Map()
-    const mapOfMutilatedIds: Map<string, string> = new Map()
-    const mapOfSingleVersionIdsWithoutExplicitVersion: Map<string, string> = new Map()
-    listOfOfficialIds.forEach(id => {
-        mapOfLowercaseIds.set(id.toLowerCase(), id)
-        mapOfMutilatedIds.set(mutilateId(id), id)
+    const mutilateId = (id: string): string => id.toUpperCase().replace(/[^0-9a-zA-Z\+]/g, "");
+    const listOfOfficialIds: string[] = ids;
+    const mapOfLowercaseIds: Map<string, string> = new Map();
+    const mapOfMutilatedIds: Map<string, string> = new Map();
+    const mapOfSingleVersionIdsWithoutExplicitVersion: Map<string, string> = new Map();
+    listOfOfficialIds.forEach((id) => {
+        mapOfLowercaseIds.set(id.toLowerCase(), id);
+        mapOfMutilatedIds.set(mutilateId(id), id);
         if (idEndsWithVersionNumber(id) && countVersionsOf(listOfOfficialIds, id) === 1) {
-            mapOfSingleVersionIdsWithoutExplicitVersion.set(removeVersionNumberFromId(id.toLowerCase()), id)
+            mapOfSingleVersionIdsWithoutExplicitVersion.set(removeVersionNumberFromId(id.toLowerCase()), id);
         }
-    })
-    const getExactMatch = (id: string) => listOfOfficialIds.find(x => x === id)
+    });
+    const getExactMatch = (id: string) => listOfOfficialIds.find((x) => x === id);
     const getCaseInsensitiveMatch = (id: string) => {
         const lowercaseId: string = id.toLowerCase();
-        const variationsToTest: string[] = [
-            lowercaseId,
-            lowercaseId.replace(/\s+/g, '-').replace(/(\d+)$/, '$1.0')
-        ]
-        return variationsToTest.map(x => mapOfLowercaseIds.get(x)).filter(m => !!m)[0]
-    }
-    const getFuzzyMatch = (id: string) => mapOfMutilatedIds.get(mutilateId(id))
-    const getSingleVersionMatch = (id: string) => mapOfSingleVersionIdsWithoutExplicitVersion.get(id)
+        const variationsToTest: string[] = [lowercaseId, lowercaseId.replace(/\s+/g, "-").replace(/(\d+)$/, "$1.0")];
+        return variationsToTest.map((x) => mapOfLowercaseIds.get(x)).filter((m) => !!m)[0];
+    };
+    const getFuzzyMatch = (id: string) => mapOfMutilatedIds.get(mutilateId(id));
+    const getSingleVersionMatch = (id: string) => mapOfSingleVersionIdsWithoutExplicitVersion.get(id);
     const get = (id: string): string | undefined => {
-        return getExactMatch(id) || getCaseInsensitiveMatch(id) || getFuzzyMatch(id) || getSingleVersionMatch(id)
-    }
-    const list = (): string[] => listOfOfficialIds
-    return { get, list } as MapOfIds
-}
+        return getExactMatch(id) || getCaseInsensitiveMatch(id) || getFuzzyMatch(id) || getSingleVersionMatch(id);
+    };
+    const list = (): string[] => listOfOfficialIds;
+    return { get, list } as MapOfIds;
+};
 
-const mapOfKnownLicenses: MapOfIds = createMapOfIds(licenses.licenses.filter(lic => !!lic.licenseId).map(lic => lic.licenseId))
-const mapOfKnownExceptions: MapOfIds = createMapOfIds(exceptions.exceptions.filter(e => !!e.licenseExceptionId).map(e => e.licenseExceptionId))
+const mapOfKnownLicenses: MapOfIds = createMapOfIds(
+    licenses.filter((lic) => !!lic.licenseId).map((lic) => lic.licenseId)
+);
+const mapOfKnownExceptions: MapOfIds = createMapOfIds(
+    exceptions.filter((e) => !!e.licenseExceptionId).map((e) => e.licenseExceptionId)
+);
 
 const aliasesForLicenseIds: Map<string, string> = ((): Map<string, string> => {
-    const mapOfAliases = new Map()
+    const mapOfAliases = new Map();
 
     // Aliases for the BSD-2-Clause license:
-    mapOfAliases.set('freebsd', 'BSD-2-Clause')
-    mapOfAliases.set('freebsd license', 'BSD-2-Clause')
-    mapOfAliases.set('freebsd license', 'BSD-2-Clause')
-    mapOfAliases.set('simplified bsd license', 'BSD-2-Clause')
+    mapOfAliases.set("freebsd", "BSD-2-Clause");
+    mapOfAliases.set("freebsd license", "BSD-2-Clause");
+    mapOfAliases.set("freebsd license", "BSD-2-Clause");
+    mapOfAliases.set("simplified bsd license", "BSD-2-Clause");
 
     // Aliases for the BSD-3-Clause license:
-    mapOfAliases.set('new bsd license', 'BSD-3-Clause')
-    mapOfAliases.set('modified bsd license', 'BSD-3-Clause')
+    mapOfAliases.set("new bsd license", "BSD-3-Clause");
+    mapOfAliases.set("modified bsd license", "BSD-3-Clause");
 
     // Aliases for the 0BSD license:
-    mapOfAliases.set('zero-clause bsd', '0BSD')
-    mapOfAliases.set('free public license', '0BSD')
-    mapOfAliases.set('free public license 1.0.0', '0BSD')
-    mapOfAliases.set('free public license 1.0', '0BSD')
-    mapOfAliases.set('bsd0', '0BSD')
+    mapOfAliases.set("zero-clause bsd", "0BSD");
+    mapOfAliases.set("free public license", "0BSD");
+    mapOfAliases.set("free public license 1.0.0", "0BSD");
+    mapOfAliases.set("free public license 1.0", "0BSD");
+    mapOfAliases.set("bsd0", "0BSD");
 
     // Aliases for the Apache-1.1 license:
-    mapOfAliases.set('apache1.1', 'Apache-1.1')
-    mapOfAliases.set('apache-1.1', 'Apache-1.1')
-    mapOfAliases.set('apache software license', 'Apache-1.1')
-    mapOfAliases.set('apache software license 1.1', 'Apache-1.1')
-    mapOfAliases.set('apache software license version 1.1', 'Apache-1.1')
+    mapOfAliases.set("apache1.1", "Apache-1.1");
+    mapOfAliases.set("apache-1.1", "Apache-1.1");
+    mapOfAliases.set("apache software license", "Apache-1.1");
+    mapOfAliases.set("apache software license 1.1", "Apache-1.1");
+    mapOfAliases.set("apache software license version 1.1", "Apache-1.1");
 
     // GNU Free Documentation License v1.1
     //mapOfAliases.set('GFDL-1.1', 'GNU Free Documentation License v1.1')
 
-    return mapOfAliases
-})()
+    return mapOfAliases;
+})();
 
 const aliasesForExceptions: Map<string, string> = ((): Map<string, string> => {
-    const mapOfAliases = new Map<string, string>()
-    mapOfAliases.set('qwt license 1.0', 'Qwt-exception-1.0')
-    mapOfAliases.set('qwt license 1', 'Qwt-exception-1.0')
-    mapOfAliases.set('cpe', 'Classpath-exception-2.0')
-    mapOfAliases.set('gnu cpe', 'Classpath-exception-2.0')
-    return mapOfAliases
-})()
+    const mapOfAliases = new Map<string, string>();
+    mapOfAliases.set("qwt license 1.0", "Qwt-exception-1.0");
+    mapOfAliases.set("qwt license 1", "Qwt-exception-1.0");
+    mapOfAliases.set("cpe", "Classpath-exception-2.0");
+    mapOfAliases.set("gnu cpe", "Classpath-exception-2.0");
+    return mapOfAliases;
+})();
 
 const mapLicenseAlias = (alias: string): string | undefined => {
-    return aliasesForLicenseIds.get(alias.toLowerCase())
-}
+    return aliasesForLicenseIds.get(alias.toLowerCase());
+};
 
 const mapLicenseId = (id: string): string | undefined => {
-    return mapOfKnownLicenses.get(id.toLowerCase())
-}
+    return mapOfKnownLicenses.get(id.toLowerCase());
+};
 
 const shouldIgnoreCorrection = (input: string, output: string): boolean => {
     // known bug in spdx-correcting e.g. "GNU Free Documentation License v1.1" into GPL-3.0-or-later:
-    return output?.startsWith('GPL-') && input.includes('Free Documentation License')
-}
+    return output?.startsWith("GPL-") && input.includes("Free Documentation License");
+};
 
 const fixLicenseId = (id: string, upgradeGPLVariants: boolean): string | null => {
     // Don't try to correct license identifiers that are syntactically legit on the
     // surface and have an explicit version number such as "3.0" or "2.1":
     if (id.match(/(\w+(\-\w+)*)\-\d+(\.\d+)+(\-\w+)*/)) {
-        return id
+        return id;
     }
 
     // Use `spdx-correct` to try and correct identifiers that we haven't fixed already:
-    const corrected = spdxCorrect(id, { upgrade: upgradeGPLVariants })
+    const corrected = spdxCorrect(id, { upgrade: upgradeGPLVariants });
     if (corrected && !shouldIgnoreCorrection(id, corrected)) {
-        return corrected
+        return corrected;
     }
-    return null
-}
+    return null;
+};
 
 const mapExceptionAlias = (alias: string): string | undefined => {
-    return aliasesForExceptions.get(alias.toLowerCase())
-}
+    return aliasesForExceptions.get(alias.toLowerCase());
+};
 
 const mapExceptionId = (id: string): string | undefined => {
-    return mapOfKnownExceptions.get(id.toLowerCase())
-}
+    return mapOfKnownExceptions.get(id.toLowerCase());
+};
 
 const knownExceptionIdentifiersStartingWith = (prefix: string): string[] => {
-    const lowercasedPrefix = prefix.toLowerCase()
-    return mapOfKnownExceptions.list()
-        .filter(id => id.toLowerCase().startsWith(lowercasedPrefix))                    // Must start with the prefix (ignoring case)
-        .filter(id => id.substring(lowercasedPrefix.length).match(/^\-?\d+(\.\d+)*$/))  // The suffix must be strictly a version number like "[prefix]-2.0" or "[prefix]3.0"
-}
+    const lowercasedPrefix = prefix.toLowerCase();
+    return mapOfKnownExceptions
+        .list()
+        .filter((id) => id.toLowerCase().startsWith(lowercasedPrefix)) // Must start with the prefix (ignoring case)
+        .filter((id) => id.substring(lowercasedPrefix.length).match(/^\-?\d+(\.\d+)*$/)); // The suffix must be strictly a version number like "[prefix]-2.0" or "[prefix]3.0"
+};
 
-const fixExceptionid = (id: string, associatedLicense?: string|undefined): string | undefined => {
-    type Mutation = (s: string) => string
+const fixExceptionid = (id: string, associatedLicense?: string | undefined): string | undefined => {
+    type Mutation = (s: string) => string;
 
     const mutations: Mutation[] = [
-        (id: string): string => id.replace(/\s+/, '-'),
-        (id: string): string => id.replace(/\s+version\s+/i, ' '),
-        (id: string): string => id.replace(/([^.])(\d+)$/, '$1$2.0'),   // replace a trailing "3" with "3.0" but don't append another ".0" to e.g. "3.0"
-        (id: string): string => id.replace(/^GNU (.*)$/i, '$1'),
-        (id: string): string => id.replace(/(.+)\s+\(.+?\)((v|version )?\d\.\d)?/gi, '$1$2'),
-    ]
-    const permutations = permutationsOf<Mutation>(mutations, 3)
-    const potentialIdentifiers = [...new Set(permutations.map((combo: Mutation[]): string => {
-        const initialValue = combo[0](id)
-        return combo.slice(1).reduce((prev, curr) => curr(prev), initialValue)
-    }))]
-    const matchedIds = [ ...new Set(potentialIdentifiers.map(mapExceptionId).filter(id => !!id)) ]
+        (id: string): string => id.replace(/\s+/, "-"),
+        (id: string): string => id.replace(/\s+version\s+/i, " "),
+        (id: string): string => id.replace(/([^.])(\d+)$/, "$1$2.0"), // replace a trailing "3" with "3.0" but don't append another ".0" to e.g. "3.0"
+        (id: string): string => id.replace(/^GNU (.*)$/i, "$1"),
+        (id: string): string => id.replace(/(.+)\s+\(.+?\)((v|version )?\d\.\d)?/gi, "$1$2"),
+    ];
+    const permutations = permutationsOf<Mutation>(mutations, 3);
+    const potentialIdentifiers = [
+        ...new Set(
+            permutations.map((combo: Mutation[]): string => {
+                const initialValue = combo[0](id);
+                return combo.slice(1).reduce((prev, curr) => curr(prev), initialValue);
+            })
+        ),
+    ];
+    const matchedIds = [...new Set(potentialIdentifiers.map(mapExceptionId).filter((id) => !!id))];
 
     if (matchedIds.length === 0 && !id.match(/\d+(\.\d+)*$/)) {
         // If the identifier to fix looks like "autoconf exception" without a "2.0" or "-2.0" suffix,
         // try to look for partial matches in the list of known exceptions (e.g. "autoconf-exception-2.0" and "autoconf-exception-3.0")
-        const prefixMatchedIds = [ ...new Set(potentialIdentifiers.flatMap(knownExceptionIdentifiersStartingWith)) ]
+        const prefixMatchedIds = [...new Set(potentialIdentifiers.flatMap(knownExceptionIdentifiersStartingWith))];
         if (prefixMatchedIds.length > 1 && associatedLicense) {
-            return selectBestMatchByAssociation(prefixMatchedIds, associatedLicense)
+            return selectBestMatchByAssociation(prefixMatchedIds, associatedLicense);
         } else {
-            return prefixMatchedIds[0]
+            return prefixMatchedIds[0];
         }
     }
 
-    return matchedIds[0]
-}
+    return matchedIds[0];
+};
 
 type PartialExpandLicenseOptions = {
-    expandScope?: boolean
-}
+    expandScope?: boolean;
+};
 
 type FullExpandLicenseOptions = {
-    expandScope: boolean
-}
+    expandScope: boolean;
+};
 
 export const expandLicenses = (identifiers: string[], providedOptions?: PartialExpandLicenseOptions): string[] => {
-    const defaultOptions: FullExpandLicenseOptions = { expandScope: false }
-    const effectiveOptions: FullExpandLicenseOptions = { ...defaultOptions, ...providedOptions }
-    const expandedList = [...identifiers]
-    identifiers.forEach(id => {
+    const defaultOptions: FullExpandLicenseOptions = { expandScope: false };
+    const effectiveOptions: FullExpandLicenseOptions = { ...defaultOptions, ...providedOptions };
+    const expandedList = [...identifiers];
+    identifiers.forEach((id) => {
         if (id.match(/[^\+]\+$/)) {
-            expandedList.push(id.replace(/\+$/, '-or-later'))
-            expandedList.push(id.replace(/\+$/, '-and-later'))
-            expandedList.push(id.replace(/\+$/, ''))
+            expandedList.push(id.replace(/\+$/, "-or-later"));
+            expandedList.push(id.replace(/\+$/, "-and-later"));
+            expandedList.push(id.replace(/\+$/, ""));
         } else if (id.match(/-(or|and)-later$/)) {
-            expandedList.push(id.replace(/-or-later$/, '-and-later'))
-            expandedList.push(id.replace(/-and-later$/, '-or-later'))
-            expandedList.push(id.replace(/-(or|and)-later$/, ''))
+            expandedList.push(id.replace(/-or-later$/, "-and-later"));
+            expandedList.push(id.replace(/-and-later$/, "-or-later"));
+            expandedList.push(id.replace(/-(or|and)-later$/, ""));
         } else if (id.match(/-only$/)) {
             if (effectiveOptions.expandScope) {
-                expandedList.push(id.replace(/-only$/, ''))
+                expandedList.push(id.replace(/-only$/, ""));
             }
         } else if (id.match(/[AL]?GPL\-\d\.\d$/)) {
-            expandedList.push(`${id}-only`)
-            expandedList.push(`${id}-or-later`)
-            expandedList.push(`${id}-and-later`)
+            expandedList.push(`${id}-only`);
+            expandedList.push(`${id}-or-later`);
+            expandedList.push(`${id}-and-later`);
         }
-    })
-    return [...new Set(expandedList)].sort()
-}
+    });
+    return [...new Set(expandedList)].sort();
+};
 
 const selectBestMatchByAssociation = (candidateExceptionIds: string[], associatedLicense: string): string => {
-    type StrengthOfRelation = { strength: number, exception: Exception }
+    type StrengthOfRelation = { strength: number; exception: Exception };
 
     const strengthOfRelation = (exception: Exception, license?: string): StrengthOfRelation => {
         if (license) {
-            const stronglyRelatedLicenses = expandLicenses(exception.relatedLicenses || [], { expandScope: false })
-            if (stronglyRelatedLicenses.includes(license)) return { strength: 2, exception }
+            const stronglyRelatedLicenses = expandLicenses(exception.relatedLicenses || [], { expandScope: false });
+            if (stronglyRelatedLicenses.includes(license)) return { strength: 2, exception };
 
-            const weaklyRelatedLicenses = expandLicenses(exception.relatedLicenses || [], { expandScope: true })
-            if (weaklyRelatedLicenses.includes(license)) return { strength: 1, exception }
+            const weaklyRelatedLicenses = expandLicenses(exception.relatedLicenses || [], { expandScope: true });
+            if (weaklyRelatedLicenses.includes(license)) return { strength: 1, exception };
         }
-        return { strength: 0, exception }
-    }
+        return { strength: 0, exception };
+    };
 
     const possibleMatches = candidateExceptionIds
-        .map(id => exceptions.exceptions.find(e => e.licenseExceptionId === id))
-        .filter(e => !!e).map(e => e as Exception)
-        .map(e => strengthOfRelation(e, associatedLicense))
+        .map((id) => exceptions.find((e) => e.licenseExceptionId === id))
+        .filter((e) => !!e)
+        .map((e) => e as Exception)
+        .map((e) => strengthOfRelation(e, associatedLicense))
         .sort((a: StrengthOfRelation, b: StrengthOfRelation) => b.strength - a.strength)
-        .map(match => match.exception)
+        .map((match) => match.exception);
 
     if (possibleMatches.length > 0) {
         // In case there are multiple possible matches - typically because there are multiple
         // versions of a given exception (e.g. "Bison-exception-1.24" and "Bison-exception-2.2")
         // - we'll pick the last one, i.e. the most recent one:
         if (possibleMatches.length > 1) {
-            const matchesAssociatedToLicense = possibleMatches.filter(e => expandLicenses(e.relatedLicenses || []).includes(associatedLicense))
+            const matchesAssociatedToLicense = possibleMatches.filter((e) =>
+                expandLicenses(e.relatedLicenses || []).includes(associatedLicense)
+            );
             if (matchesAssociatedToLicense.length > 0) {
-                return matchesAssociatedToLicense[0]?.licenseExceptionId
+                return matchesAssociatedToLicense[0]?.licenseExceptionId;
             }
         }
-        return possibleMatches[0]?.licenseExceptionId
+        return possibleMatches[0]?.licenseExceptionId;
     }
-    return candidateExceptionIds[0]
-}
+    return candidateExceptionIds[0];
+};
 
 /**
  * Fix the given license identifier, if possible, or return it unchanged.
@@ -251,67 +259,66 @@ const selectBestMatchByAssociation = (candidateExceptionIds: string[], associate
  * @returns A corrected SPDX license identifier or the original, if no suitable "fix" was found
  */
 export function correctLicenseId(identifier: string, upgradeGPLVariants: boolean): string {
-
-    const mapLicense = (id: string): string|undefined => mapLicenseId(id) || mapLicenseAlias(id)
+    const mapLicense = (id: string): string | undefined => mapLicenseId(id) || mapLicenseAlias(id);
 
     // The `spdx-correct` package does not have fixes for everything (e.g. a common misspelling for the
     // zero-clause variant of the BSD license or for names such as "The Simplified BSD license") so we'll
     // check for a list of known aliases ourselves:
     const applyAliases = (id: string): string => {
-        const lowercaseId = id.replace(/^the /i, '')
-        return mapLicense(lowercaseId) || mapLicense(`the ${lowercaseId}`) || id
-    }
+        const lowercaseId = id.replace(/^the /i, "");
+        return mapLicense(lowercaseId) || mapLicense(`the ${lowercaseId}`) || id;
+    };
 
     // The `spdx-correct` package will coerce "GPL-3.0" into "GPL-3.0-or-later", although
     // "GPL-3.0-only" would be more true to the original intent:
     const applyGPLFixes = (id: string): string => {
-        const onlySuffix = upgradeGPLVariants ? '-only' : ''
-        if (upgradeGPLVariants && mapLicense(id)) return mapLicense(`${id}${onlySuffix}`) || id
-        if (id.toUpperCase() === 'GPL') return mapLicense(`GPL-3.0${onlySuffix}`) || id
-        if (id.toUpperCase() === 'LGPL') return mapLicense(`LGPL-3.0${onlySuffix}`) || id
-        if (id.toUpperCase() === 'AGPL') return mapLicense(`AGPL-3.0${onlySuffix}`) || id
+        const onlySuffix = upgradeGPLVariants ? "-only" : "";
+        if (upgradeGPLVariants && mapLicense(id)) return mapLicense(`${id}${onlySuffix}`) || id;
+        if (id.toUpperCase() === "GPL") return mapLicense(`GPL-3.0${onlySuffix}`) || id;
+        if (id.toUpperCase() === "LGPL") return mapLicense(`LGPL-3.0${onlySuffix}`) || id;
+        if (id.toUpperCase() === "AGPL") return mapLicense(`AGPL-3.0${onlySuffix}`) || id;
 
         // Expand a single-digit "GPL2+" or "GPLv3" into a "-2.0+" or "-3.0" with the trailing zero
         if (id.match(/^([AL]?GPL)([\-vV]?)(\d)(\+?)$/)) {
-            return applyGPLFixes(id.replace(/^([AL]?GPL)([\-vV]?)(\d)(\+?)$/, '$1-$3.0$4'))
+            return applyGPLFixes(id.replace(/^([AL]?GPL)([\-vV]?)(\d)(\+?)$/, "$1-$3.0$4"));
         }
 
         // Correct the '-and-later' to the canonical '-or-later'
         if (id.match(/^([AL]?GPL.*)(\-and\-later)$/)) {
-            const candidateId = id.replace(/([AL]?GPL.*)(\-and\-later)$/, '$1-or-later')
-            return applyGPLFixes(candidateId) || id
+            const candidateId = id.replace(/([AL]?GPL.*)(\-and\-later)$/, "$1-or-later");
+            return applyGPLFixes(candidateId) || id;
         }
 
         // Expand the '+' syntax to the canonical '-or-later'
         if (id.match(/^([AL]?GPL[\-vV]?\d)(\+)$/)) {
-            const candidateId = id.replace(/([AL]?GPL[\-vV]?\d)(\+)$/, '$1.0-or-later')
-            return mapLicense(candidateId) || id
+            const candidateId = id.replace(/([AL]?GPL[\-vV]?\d)(\+)$/, "$1.0-or-later");
+            return mapLicense(candidateId) || id;
         }
 
-        return id
-    }
+        return id;
+    };
 
     // Expand the "+" syntax to "-or-later" if one exists:
     const expandPlus = (id: string): string => {
         if (id.match(/[^\+]\+$/)) {
-            const orLaterId = id.replace(/\+$/, '-or-later')
-            return mapLicense(orLaterId) || id
+            const orLaterId = id.replace(/\+$/, "-or-later");
+            return mapLicense(orLaterId) || id;
         }
-        return id
-    }
+        return id;
+    };
 
     // If the license identifier contains a "-with-" substring, it's an expression, not
     // a single identifier so let's not try to "fix" it at this point:
-    if (identifier.includes('-with-')) return identifier
+    if (identifier.includes("-with-")) return identifier;
 
-    const aliased = applyAliases(identifier)
+    const aliased = applyAliases(identifier);
     if (aliased !== identifier) {
         // the identifier was successfully aliased – let's retry with the alias!
-        return correctLicenseId(aliased, upgradeGPLVariants)
+        return correctLicenseId(aliased, upgradeGPLVariants);
     }
 
-    const id = expandPlus(applyGPLFixes(aliased))
-    return mapLicense(id) || fixLicenseId(id, upgradeGPLVariants) || id
+    const id = expandPlus(applyGPLFixes(aliased));
+    return mapLicense(id) || fixLicenseId(id, upgradeGPLVariants) || id;
 }
 
 /**
@@ -321,121 +328,120 @@ export function correctLicenseId(identifier: string, upgradeGPLVariants: boolean
  * @returns A corrected SPDX exception identifier or the original, if no suitable "fix" was found
  */
 export function correctExceptionId(identifier: string, associatedLicense?: string): string {
-
     const removeExtras = (id: string): string => {
-        return id.trim()
-            .replace(/^the\s+/i, '')
-            .replace(/\s+/, ' ')
-            .replace(/^gnu/, '')
+        return id
             .trim()
-    }
+            .replace(/^the\s+/i, "")
+            .replace(/\s+/, " ")
+            .replace(/^gnu/, "")
+            .trim();
+    };
 
     const applyAliases = (id: string): string => {
-        const lowercaseId = id.toLowerCase()
-        const lowercaseIdWithoutWordVersion = lowercaseId.replace(/\s+version\s+(\d+)/, ' $1')
-        return mapExceptionAlias(lowercaseId) || mapExceptionAlias(lowercaseIdWithoutWordVersion) || id
-    }
+        const lowercaseId = id.toLowerCase();
+        const lowercaseIdWithoutWordVersion = lowercaseId.replace(/\s+version\s+(\d+)/, " $1");
+        return mapExceptionAlias(lowercaseId) || mapExceptionAlias(lowercaseIdWithoutWordVersion) || id;
+    };
 
-    const id = applyAliases(removeExtras(identifier))
-    return mapExceptionId(id) || fixExceptionid(id, associatedLicense) || id
+    const id = applyAliases(removeExtras(identifier));
+    return mapExceptionId(id) || fixExceptionid(id, associatedLicense) || id;
 }
 
 export function isKnownLicenseId(id: string): boolean {
-    return !!mapLicenseId(id)
+    return !!mapLicenseId(id);
 }
 
 export function isKnownExceptionId(id: string): boolean {
-    return !!mapExceptionId(id)
+    return !!mapExceptionId(id);
 }
 
 export function fixDashedLicenseInfo(node: LicenseInfo, upgradeGPLVariants: boolean): LicenseInfo {
-    if (!node.exception && node.license.includes('-with-') && !isKnownLicenseId(node.license)) {
+    if (!node.exception && node.license.includes("-with-") && !isKnownLicenseId(node.license)) {
         // let's see if we can map the parts to actual known identifiers
-        const [splitLicense, splitException] = node.license.split('-with-')
-        const fixedLicense = correctLicenseId(splitLicense, upgradeGPLVariants)
-        const fixedException = correctExceptionId(splitException, fixedLicense)
+        const [splitLicense, splitException] = node.license.split("-with-");
+        const fixedLicense = correctLicenseId(splitLicense, upgradeGPLVariants);
+        const fixedException = correctExceptionId(splitException, fixedLicense);
         if (isKnownLicenseId(fixedLicense)) {
-            return { license: fixedLicense, exception: fixedException } as LicenseInfo
+            return { license: fixedLicense, exception: fixedException } as LicenseInfo;
         }
     }
-    return node
+    return node;
 }
 
 export const variationsOf = (name: string, upgradeGPLVariants: boolean): string[] => {
-
-    const versionPrefixVariationsOf = (_value: string): string[] => [' version ', ' v', ' ']
+    const versionPrefixVariationsOf = (_value: string): string[] => [" version ", " v", " "];
 
     const namePrefixVariationsOf = (value: string): string[] => {
-        const namePrefixVariations = [value]
-        if (value.startsWith('gnu ')) {
-            namePrefixVariations.push(value.substring('gnu '.length))
+        const namePrefixVariations = [value];
+        if (value.startsWith("gnu ")) {
+            namePrefixVariations.push(value.substring("gnu ".length));
         } else if (value.match(/^((lesser|affero) )?general public license/)) {
-            namePrefixVariations.push(`gnu ${value}`)
+            namePrefixVariations.push(`gnu ${value}`);
         }
-        return namePrefixVariations
-    }
+        return namePrefixVariations;
+    };
 
-    const suffixVariationsOf = (value: string|undefined): string[] => {
-        const fixedAlternatives = [' or greater', ' or later', ' or newer']
+    const suffixVariationsOf = (value: string | undefined): string[] => {
+        const fixedAlternatives = [" or greater", " or later", " or newer"];
         if (value === undefined) {
             if (upgradeGPLVariants) {
-                return ['', ' only']
+                return ["", " only"];
             } else {
-                return ['']
+                return [""];
             }
         } else if (fixedAlternatives.includes(value)) {
-            return [ value, ...fixedAlternatives.filter(x => x !== value) ]
+            return [value, ...fixedAlternatives.filter((x) => x !== value)];
         } else {
-            return [value]
+            return [value];
         }
-    }
+    };
 
     const versionNumberVariationsOf = (value: string): string[] => {
-        const versionNumberVariations = [value]
-        if (value.endsWith('.0')) {
+        const versionNumberVariations = [value];
+        if (value.endsWith(".0")) {
             // For "3.1.0", let's also try "3.1"
-            versionNumberVariations.push(value.replace(/\.0$/, ''))
-            if (value.endsWith('.0.0')) {
+            versionNumberVariations.push(value.replace(/\.0$/, ""));
+            if (value.endsWith(".0.0")) {
                 // For "3.0.0", let's also try "3"
-                versionNumberVariations.push(value.replace(/\.0\.0$/, ''))
+                versionNumberVariations.push(value.replace(/\.0\.0$/, ""));
             }
-        } else if (!value.includes('.')) {
+        } else if (!value.includes(".")) {
             // For "3", let's also try "3.0"
-            versionNumberVariations.push(`${value}.0`)
+            versionNumberVariations.push(`${value}.0`);
         }
-        return versionNumberVariations
-    }
+        return versionNumberVariations;
+    };
 
-    const variations: string[] = [name]
-    const versionMatch = name.match(/^(.+)(\sversion\s|\sv)(\d+(\.\d+)*)(\+|(\s.*))?$/)
+    const variations: string[] = [name];
+    const versionMatch = name.match(/^(.+)(\sversion\s|\sv)(\d+(\.\d+)*)(\+|(\s.*))?$/);
     if (versionMatch) {
-        const namePrefixVariations = namePrefixVariationsOf(versionMatch[1])
-        const suffixVariations = suffixVariationsOf(versionMatch[5])
-        const versionPrefixVariations = versionPrefixVariationsOf(versionMatch[2])
-        const versionNumberVariations = versionNumberVariationsOf(versionMatch[3])
+        const namePrefixVariations = namePrefixVariationsOf(versionMatch[1]);
+        const suffixVariations = suffixVariationsOf(versionMatch[5]);
+        const versionPrefixVariations = versionPrefixVariationsOf(versionMatch[2]);
+        const versionNumberVariations = versionNumberVariationsOf(versionMatch[3]);
 
-        namePrefixVariations.forEach(namePrefix => {
-            versionPrefixVariations.forEach(versionPrefix => {
-                versionNumberVariations.forEach(versionNumber => {
-                    suffixVariations.forEach(suffix => {
-                        variations.push(`${namePrefix}${versionPrefix}${versionNumber}${suffix}`)
-                    })
-                })
-            })
-        })
+        namePrefixVariations.forEach((namePrefix) => {
+            versionPrefixVariations.forEach((versionPrefix) => {
+                versionNumberVariations.forEach((versionNumber) => {
+                    suffixVariations.forEach((suffix) => {
+                        variations.push(`${namePrefix}${versionPrefix}${versionNumber}${suffix}`);
+                    });
+                });
+            });
+        });
     }
     return variations.sort((a, b) => {
-        const lengthBasedSort = b.length - a.length
+        const lengthBasedSort = b.length - a.length;
         if (lengthBasedSort !== 0) {
             // string length is the primary sort key
-            return lengthBasedSort
+            return lengthBasedSort;
         } else {
             // between strings of equal length, sort alphabetically
             // (with uppercase "A" coming before lowercase "a")
-            return a.localeCompare(b, undefined, { caseFirst: 'upper' })
+            return a.localeCompare(b, undefined, { caseFirst: "upper" });
         }
-    })
-}
+    });
+};
 
 /**
  * Try to identify the license by comparing the given text with the official names of
@@ -444,11 +450,11 @@ export const variationsOf = (name: string, upgradeGPLVariants: boolean): string[
  * @param text The text that could be a license name
  * @returns The {@link License}, or `undefined`
  */
-export const findNameBasedMatch = (text: string, upgradeGPLVariants: boolean): License|undefined => {
+export const findNameBasedMatch = (text: string, upgradeGPLVariants: boolean): License | undefined => {
     const normalizeName = (name: string): string => {
-        return name.toLowerCase().replace(/,/g, ' ').replace(/\s+/, ' ')
-    }
-    const lowercaseText = normalizeName(text)
-    const variations = variationsOf(lowercaseText, upgradeGPLVariants)
-    return licenses.licenses.find(x => variations.includes(normalizeName(x.name)))
-}
+        return name.toLowerCase().replace(/,/g, " ").replace(/\s+/, " ");
+    };
+    const lowercaseText = normalizeName(text);
+    const variations = variationsOf(lowercaseText, upgradeGPLVariants);
+    return licenses.find((x) => variations.includes(normalizeName(x.name)));
+};

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -107,7 +107,7 @@ const prepareLiberalInput = (input: string): string => {
     ]
 
     // Automated, exact-name based mutations to apply, replacing license names with a matching identifier
-    const relevantLicenses = licenses.licenses.filter(license => license.name.includes('(') || license.name.match(/ and /i))
+    const relevantLicenses = licenses.filter(license => license.name.includes('(') || license.name.match(/ and /i))
     relevantLicenses.forEach(license => {
         mutations.push((input: string): string => {
             return input.replace(license.name, license.licenseId)

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,108 +1,122 @@
-import { fail } from "assert"
-import { parseSpdxExpressionWithDetails, ParsedSpdxExpression, ConjunctionInfo, LicenseInfo, LicenseRef } from "../parser"
+import { fail } from "assert";
+import {
+    parseSpdxExpressionWithDetails,
+    ParsedSpdxExpression,
+    ConjunctionInfo,
+    LicenseInfo,
+    LicenseRef,
+} from "../parser";
 
-import { exceptions, licenses, Exception } from '../licenses'
-
+import { exceptions, licenses, Exception } from "../licenses";
 
 export type ValidationResult = {
-    valid: boolean,
-    errors: string[]
-}
+    valid: boolean;
+    errors: string[];
+};
 
-const ALL_LICENSE_IDS = licenses.licenses.map(entry => entry.licenseId)
-const LOWERCASE_LICENSE_IDS = ALL_LICENSE_IDS.map(id => id.toLowerCase())
-const LOWERCASE_EXCEPTION_IDS = exceptions.exceptions.map(entry => entry.licenseExceptionId.toLowerCase())
+const ALL_LICENSE_IDS = licenses.map((entry) => entry.licenseId);
+const LOWERCASE_LICENSE_IDS = ALL_LICENSE_IDS.map((id) => id.toLowerCase());
+const LOWERCASE_EXCEPTION_IDS = exceptions.map((entry) => entry.licenseExceptionId.toLowerCase());
 
-const isKnownLicenseIdentifier = (id: string): boolean => LOWERCASE_LICENSE_IDS.includes(id.toLowerCase())
-const isKnownExceptionIdentifier = (id: string): boolean => LOWERCASE_EXCEPTION_IDS.includes(id.toLowerCase())
+const isKnownLicenseIdentifier = (id: string): boolean => LOWERCASE_LICENSE_IDS.includes(id.toLowerCase());
+const isKnownExceptionIdentifier = (id: string): boolean => LOWERCASE_EXCEPTION_IDS.includes(id.toLowerCase());
 
 type GPLIdentifier = {
-    family: string,
-    version: string,
-    plus: boolean
-}
+    family: string;
+    version: string;
+    plus: boolean;
+};
 
 const parseGplVersionFromIdentifier = (identifier: string): GPLIdentifier | undefined => {
-    const groups = identifier.match(/^([AL]?GPL)\-(\d(\.\d)+)((\-or\-later)|(\-only)|\+)?$/)
+    const groups = identifier.match(/^([AL]?GPL)\-(\d(\.\d)+)((\-or\-later)|(\-only)|\+)?$/);
     if (groups) {
-        return { family: groups[1], version: groups[2], plus: ['-or-later', '+'].includes(groups[4]) }
+        return { family: groups[1], version: groups[2], plus: ["-or-later", "+"].includes(groups[4]) };
     }
-    return undefined
-}
+    return undefined;
+};
 
 const expandGplLicenseVersionExpressions = (relatedLicenseIds: string[]): string[] => {
-    const ids: string[] = []
-    relatedLicenseIds.forEach(license => {
-        ids.push(license)
+    const ids: string[] = [];
+    relatedLicenseIds.forEach((license) => {
+        ids.push(license);
 
         if (license.match(/^[AL]?GPL\-\d(\.\d)+$/)) {
             // if "GPL-2.0" or "GPL-3.0", also allow "-only" and "-or-later" variations
-            ids.push(`${license}-only`)
-            ids.push(`${license}-or-later`)
+            ids.push(`${license}-only`);
+            ids.push(`${license}-or-later`);
         }
-        const orLaterMatch = license.match(/^([AL]?GPL)\-(\d(\.\d)+)\-(or|and)\-later$/)
+        const orLaterMatch = license.match(/^([AL]?GPL)\-(\d(\.\d)+)\-(or|and)\-later$/);
         if (orLaterMatch) {
             // if "GPL-2.0+" or "GPL-3.0-or-later" etc.
-            const licenseFamily = orLaterMatch[1]
-            const minimumVersion = orLaterMatch[2]
-            const allLicensesInSameFamily = ALL_LICENSE_IDS.filter(id => id.startsWith(`${licenseFamily}-`))
-            const newerLicensesInSameFamily = allLicensesInSameFamily.filter(id => {
-                const gplId = parseGplVersionFromIdentifier(id)
-                return gplId && gplId.version >= minimumVersion
-            })
-            newerLicensesInSameFamily.forEach(id => ids.push(id))
+            const licenseFamily = orLaterMatch[1];
+            const minimumVersion = orLaterMatch[2];
+            const allLicensesInSameFamily = ALL_LICENSE_IDS.filter((id) => id.startsWith(`${licenseFamily}-`));
+            const newerLicensesInSameFamily = allLicensesInSameFamily.filter((id) => {
+                const gplId = parseGplVersionFromIdentifier(id);
+                return gplId && gplId.version >= minimumVersion;
+            });
+            newerLicensesInSameFamily.forEach((id) => ids.push(id));
         }
-    })
-    return ids
-}
+    });
+    return ids;
+};
 
 const validateLicenseAndExceptionRelation = (licenseId: string, exceptionId: string): string[] => {
-    const relatedLicenseIds = expandGplLicenseVersionExpressions((exceptions.exceptions.find(x => {
-        return x.licenseExceptionId.toLowerCase() === exceptionId.toLowerCase()
-    })?.relatedLicenses || []))
-    if (relatedLicenseIds.length > 0 && !relatedLicenseIds.map(x => x.toLowerCase()).includes(licenseId.toLowerCase())) {
-        return [ `Exception associated with unrelated license: \"${licenseId} WITH ${exceptionId}\" (expected one of: ${relatedLicenseIds.join(', ')})` ]
+    const relatedLicenseIds = expandGplLicenseVersionExpressions(
+        exceptions.find((x) => {
+            return x.licenseExceptionId.toLowerCase() === exceptionId.toLowerCase();
+        })?.relatedLicenses || []
+    );
+    if (
+        relatedLicenseIds.length > 0 &&
+        !relatedLicenseIds.map((x) => x.toLowerCase()).includes(licenseId.toLowerCase())
+    ) {
+        return [
+            `Exception associated with unrelated license:` +
+                ` "${licenseId} WITH ${exceptionId}"` +
+                ` (expected one of: ${relatedLicenseIds.join(", ")})`,
+        ];
     }
-    return []
-}
+    return [];
+};
 
 const validateLicenseInfoExpression = (expression: LicenseInfo): string[] => {
-    const errors: string[] = []
-    const licenseId = expression.license
+    const errors: string[] = [];
+    const licenseId = expression.license;
 
     if (!isKnownLicenseIdentifier(licenseId)) {
-        errors.push(`Unknown SPDX license identifier: ${JSON.stringify(licenseId)}`)
+        errors.push(`Unknown SPDX license identifier: ${JSON.stringify(licenseId)}`);
     }
 
     if (expression.exception) {
         if (!isKnownExceptionIdentifier(expression.exception)) {
-            errors.push(`Unknown SPDX exception identifier: ${JSON.stringify(expression.exception)}`)
+            errors.push(`Unknown SPDX exception identifier: ${JSON.stringify(expression.exception)}`);
         } else {
-            const relationErrors = validateLicenseAndExceptionRelation(licenseId, expression.exception)
-            relationErrors.forEach(e => errors.push(e))
+            const relationErrors = validateLicenseAndExceptionRelation(licenseId, expression.exception);
+            relationErrors.forEach((e) => errors.push(e));
         }
     }
-    return errors
-}
+    return errors;
+};
 
 const validateLicenseRefExpression = (expression: LicenseRef): string[] => {
-    return []  // LicenseRefs are not currently validated in any way
-}
+    return []; // LicenseRefs are not currently validated in any way
+};
 
 const validateCompoundExpression = (expression: ConjunctionInfo): string[] => {
-    return validateExpression(expression.left).concat(validateExpression(expression.right))
-}
+    return validateExpression(expression.left).concat(validateExpression(expression.right));
+};
 
 const validateExpression = (expression: ParsedSpdxExpression): string[] => {
     if ((expression as ConjunctionInfo)?.conjunction) {
-        return validateCompoundExpression(expression as ConjunctionInfo)
+        return validateCompoundExpression(expression as ConjunctionInfo);
     } else if ((expression as LicenseRef)?.licenseRef) {
-        return validateLicenseRefExpression(expression as LicenseRef)
+        return validateLicenseRefExpression(expression as LicenseRef);
     } else if ((expression as LicenseInfo)?.license) {
-        return validateLicenseInfoExpression(expression as LicenseInfo)
+        return validateLicenseInfoExpression(expression as LicenseInfo);
     }
-    /* istanbul ignore next */ fail(`Unexpected type of input for validateExpression(${JSON.stringify(expression)})`)
-}
+    /* istanbul ignore next */ fail(`Unexpected type of input for validateExpression(${JSON.stringify(expression)})`);
+};
 
 /**
  * Validate the given SPDX expression.
@@ -111,17 +125,17 @@ const validateExpression = (expression: ParsedSpdxExpression): string[] => {
  * @returns a {ValidationResult} with a binary outcome and a list of validation errors.
  */
 export function validate(input: string): ValidationResult {
-    if (input.trim() === '') {
-        return { valid: false, errors: [ 'Unknown SPDX identifier: ""' ]}
+    if (input.trim() === "") {
+        return { valid: false, errors: ['Unknown SPDX identifier: ""'] };
     }
-    const parseResult = parseSpdxExpressionWithDetails(input, false, false)
+    const parseResult = parseSpdxExpressionWithDetails(input, false, false);
     if (parseResult.error) {
-        return { valid: false, errors: [ parseResult.error ] }
+        return { valid: false, errors: [parseResult.error] };
     } else if (parseResult.expression) {
-        const errors = validateExpression(parseResult.expression)
-        return { errors, valid: errors.length === 0 }
+        const errors = validateExpression(parseResult.expression);
+        return { errors, valid: errors.length === 0 };
     }
-    /* istanbul ignore next */ fail(`Unexpected execution path for validate(${JSON.stringify(input)})`)
+    /* istanbul ignore next */ fail(`Unexpected execution path for validate(${JSON.stringify(input)})`);
 }
 
-export default validate
+export default validate;

--- a/tests/corrections.licenses.test.ts
+++ b/tests/corrections.licenses.test.ts
@@ -729,7 +729,7 @@ describe('Parenthesized scenarios', () => {
             const justShortEnoughPretext = '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789' // 99 chars
             const slightlyTooLongPretext = '123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 1'  // 101 chars
 
-            const longestLicenseName = licenses.licenses.map(l => l.name.length).sort().reverse()[0]
+            const longestLicenseName = licenses.map(l => l.name.length).sort().reverse()[0]
             assert(THRESHOLD_LENGTH > longestLicenseName, `Our SPDX data contains license names longer than our hardcoded threshold of ${THRESHOLD_LENGTH} - we should probably increase the threshold!`)
             assert(justShortEnoughPretext.length < THRESHOLD_LENGTH, `Our "just short enough" pretext isn't short enough!`)
             assert(slightlyTooLongPretext.length > THRESHOLD_LENGTH, `Our "slightly too long" pretext isn't long enough!`)

--- a/tests/licenses.test.ts
+++ b/tests/licenses.test.ts
@@ -3,7 +3,7 @@ import { licenses, findNameBasedMatch, variationsOf } from '../src/licenses'
 describe('Find a name-based match for a license', () => {
 
     describe('all licenses currently in our database', () => {
-        const licenseNames = licenses.licenses.map(license => license.name).sort()
+        const licenseNames = licenses.map(license => license.name).sort()
         licenseNames.forEach(name => {
             it(name, () => expect(findNameBasedMatch(name, true)).not.toBeUndefined())
         })

--- a/tests/simple_expressions.test.ts
+++ b/tests/simple_expressions.test.ts
@@ -1,111 +1,122 @@
-import 'jest-extended'
+import "jest-extended";
 
-import { parse } from '../src'
-import licenses from '../src/codegen/licenses.json'
-import { LicenseInfo } from '../src/parser/types'
+import { parse } from "../src";
+import licenses from "../src/codegen/licenses.json";
+import { LicenseInfo } from "../src/parser/types";
 
+const nonDeprecatedLicenseIds = licenses
+    .filter((l) => !l.deprecated)
+    .map((l) => l.licenseId)
+    .sort();
+const deprecatedLicenseIds = licenses
+    .filter((l) => l.deprecated)
+    .map((l) => l.licenseId)
+    .sort();
 
-const nonDeprecatedLicenseIds = licenses.licenses.filter(l => !l.isDeprecatedLicenseId).map(l => l.licenseId).sort()
-const deprecatedLicenseIds = licenses.licenses.filter(l => l.isDeprecatedLicenseId).map(l => l.licenseId).sort()
+describe("Simple expressions", () => {
+    describe("without license exception", () => {
+        it("do not have to be actual known license identifiers", () => {
+            expect(parse("XYZ-1.2")).toStrictEqual({ license: "XYZ-1.2" });
+        });
 
-describe('Simple expressions', () => {
+        it("are trimmed of leading/trailing whitespace", () => {
+            expect(parse(" \t \n MIT")).toStrictEqual({ license: "MIT" });
+            expect(parse("MIT \t \n ")).toStrictEqual({ license: "MIT" });
+        });
 
-    describe('without license exception', () => {
+        it("all non-deprecated licenses should be parsed as-is", () => {
+            nonDeprecatedLicenseIds.forEach((id) => expect(parse(id)).toStrictEqual({ license: id }));
+        });
 
-        it('do not have to be actual known license identifiers', () => {
-            expect(parse('XYZ-1.2')).toStrictEqual({ license: 'XYZ-1.2' })
-        })
+        it("deprecated licenses might be somewhat altered around the end", () => {
+            deprecatedLicenseIds.forEach((id) => {
+                const expectedPrefix = id.replace(/\+$/, "");
+                expect((parse(id) as LicenseInfo).license).toStartWith(expectedPrefix);
+            });
+        });
 
-        it('are trimmed of leading/trailing whitespace', () => {
-            expect(parse(' \t \n MIT')).toStrictEqual({ license: 'MIT' })
-            expect(parse('MIT \t \n ')).toStrictEqual({ license: 'MIT' })
-        })
+        describe("samples (randomized)", () => {
+            describe("non-deprecated licenses", () => {
+                const randomIds = [...nonDeprecatedLicenseIds]
+                    .sort(() => 0.5 - Math.random())
+                    .slice(0, 10)
+                    .sort();
+                randomIds.forEach((id) => {
+                    it(`${id}  =>  ${id}`, () => expect(parse(id)).toStrictEqual({ license: id }));
+                });
+            });
 
-        it('all non-deprecated licenses should be parsed as-is', () => {
-            nonDeprecatedLicenseIds.forEach(id => expect(parse(id)).toStrictEqual({ license: id }))
-        })
-
-        it('deprecated licenses might be somewhat altered around the end', () => {
-            deprecatedLicenseIds.forEach(id => {
-                const expectedPrefix = id.replace(/\+$/, '')
-                expect((parse(id) as LicenseInfo).license).toStartWith(expectedPrefix)
-            })
-        })
-
-        describe('samples (randomized)', () => {
-            describe('non-deprecated licenses', () => {
-                const randomIds = [...nonDeprecatedLicenseIds].sort(() => .5 - Math.random()).slice(0, 10).sort()
-                randomIds.forEach(id => {
-                    it(`${id}  =>  ${id}`, () => expect(parse(id)).toStrictEqual({ license: id }))
-                })
-            })
-
-            describe('deprecated licenses might be somewhat altered', () => {
-                const randomIds = [...deprecatedLicenseIds].sort(() => .5 - Math.random()).slice(0, 10).sort()
-                randomIds.forEach(id => {
-                    const expectedPrefix = id.replace(/\+$/, '')
+            describe("deprecated licenses might be somewhat altered", () => {
+                const randomIds = [...deprecatedLicenseIds]
+                    .sort(() => 0.5 - Math.random())
+                    .slice(0, 10)
+                    .sort();
+                randomIds.forEach((id) => {
+                    const expectedPrefix = id.replace(/\+$/, "");
                     it(`${id} starts with ${JSON.stringify(expectedPrefix)} after alteration`, () => {
-                        expect((parse(id) as LicenseInfo).license).toStartWith(expectedPrefix)
-                    })
-                })
-            })
-        })
-    })
+                        expect((parse(id) as LicenseInfo).license).toStartWith(expectedPrefix);
+                    });
+                });
+            });
+        });
+    });
 
-    describe('that are license references', () => {
-        it('are identified as licencerefs, not license identifiers', () => {
-            expect(parse('LicenseRef-MIT-Style-1')).toStrictEqual({
+    describe("that are license references", () => {
+        it("are identified as licencerefs, not license identifiers", () => {
+            expect(parse("LicenseRef-MIT-Style-1")).toStrictEqual({
                 documentRef: undefined,
-                licenseRef: 'LicenseRef-MIT-Style-1'
-            })
-            expect(parse('LicenseRef-23')).toStrictEqual({
+                licenseRef: "LicenseRef-MIT-Style-1",
+            });
+            expect(parse("LicenseRef-23")).toStrictEqual({
                 documentRef: undefined,
-                licenseRef: 'LicenseRef-23'
-            })
-            expect(parse('DocumentRef-X:LicenseRef-Y')).toStrictEqual({
-                documentRef: 'DocumentRef-X',
-                licenseRef: 'LicenseRef-Y'
-            })
-        })
+                licenseRef: "LicenseRef-23",
+            });
+            expect(parse("DocumentRef-X:LicenseRef-Y")).toStrictEqual({
+                documentRef: "DocumentRef-X",
+                licenseRef: "LicenseRef-Y",
+            });
+        });
 
-        it('includes a DocumentRef when available', () => {
-            const fullResult = parse('DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2')
+        it("includes a DocumentRef when available", () => {
+            const fullResult = parse("DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2");
             expect(fullResult).toMatchObject({
-                documentRef: 'DocumentRef-spdx-tool-1.2',
-                licenseRef: 'LicenseRef-MIT-Style-2'
-            })
-        })
-    })
+                documentRef: "DocumentRef-spdx-tool-1.2",
+                licenseRef: "LicenseRef-MIT-Style-2",
+            });
+        });
+    });
 
-    describe('with license exception', () => {
-        it('identifies the exception along with the license it belongs to', () => {
-            expect(parse('GPL-3.0-only WITH Autoconf-exception-2.0')).toStrictEqual({
-                license: 'GPL-3.0-only', exception: 'Autoconf-exception-2.0'
-            })
-        })
+    describe("with license exception", () => {
+        it("identifies the exception along with the license it belongs to", () => {
+            expect(parse("GPL-3.0-only WITH Autoconf-exception-2.0")).toStrictEqual({
+                license: "GPL-3.0-only",
+                exception: "Autoconf-exception-2.0",
+            });
+        });
 
-        describe('examples', () => {
-            const licenseName = 'GPL-3.0-only'
-            const exceptions = ['Bison-exception-2.2', 'Autoconf-exception-3.0']
-            exceptions.forEach(exceptionName => {
+        describe("examples", () => {
+            const licenseName = "GPL-3.0-only";
+            const exceptions = ["Bison-exception-2.2", "Autoconf-exception-3.0"];
+            exceptions.forEach((exceptionName) => {
                 it(`${licenseName} WITH ${exceptionName}`, () => {
                     expect(parse(`${licenseName} WITH ${exceptionName}`)).toStrictEqual({
-                        license: licenseName, exception: exceptionName
-                    })
-                })
-            })
-        })
-    })
+                        license: licenseName,
+                        exception: exceptionName,
+                    });
+                });
+            });
+        });
+    });
 
-    describe('with a syntactically correct but unknown exception', () => {
-        it('render the identifier in its original form', () => {
-            expect(parse('MIT WITH Fake-1.1')).toStrictEqual({ license: 'MIT', exception: 'Fake-1.1' })
-        })
-    })
+    describe("with a syntactically correct but unknown exception", () => {
+        it("render the identifier in its original form", () => {
+            expect(parse("MIT WITH Fake-1.1")).toStrictEqual({ license: "MIT", exception: "Fake-1.1" });
+        });
+    });
 
-    describe('with a syntactically correct but unknown license', () => {
-        it('render the identifier in its original form', () => {
-            expect(parse('Fake')).toStrictEqual({ license: 'Fake' })
-        })
-    })
-})
+    describe("with a syntactically correct but unknown license", () => {
+        it("render the identifier in its original form", () => {
+            expect(parse("Fake")).toStrictEqual({ license: "Fake" });
+        });
+    });
+});


### PR DESCRIPTION
Use `licenses-from-spdx` for acquiring raw license data from SPDX. We still identify relationships between an exception and which (version of a) license it applies to within our own code but this offloads some of the work to a separate library.